### PR TITLE
Preserve whitespace when reading SAML response from Idp. 

### DIFF
--- a/Kentor.AuthServices/Saml2Response.cs
+++ b/Kentor.AuthServices/Saml2Response.cs
@@ -29,6 +29,7 @@ namespace Kentor.AuthServices
         public static Saml2Response Read(string xml)
         {
             var x = new XmlDocument();
+            x.PreserveWhitespace = true;
             x.LoadXml(xml);
 
             if (x.DocumentElement.LocalName != "Response"


### PR DESCRIPTION
This fixes problems with verifying xml signatures from Idp's that are returning XML containing whitespaces or line breaks.

When using this Kentor.AuthServices together with a simplesamlphp idp, the verification of the xml signature failed. This was due to line breaks in the SAML response.
