### PR TITLE
Make SampleMvcApplication point to local StubIdp

### DIFF
--- a/SampleMvcApplication/Web.config
+++ b/SampleMvcApplication/Web.config
@@ -33,7 +33,7 @@
   </system.webServer>
   <kentor.authServices issuer="http://localhost:2181/"
                        returnUri="http://localhost:2181/">
-    <identityProvider issuer ="Kentor.AuthServices.StubIdp" destinationUri="https://idp.example.com"
+    <identityProvider issuer ="Kentor.AuthServices.StubIdp" destinationUri="http://localhost:52071/"
                        allowUnsolicitedAuthnResponse="true" binding="HttpRedirect">
       <signingCertificate fileName="~/App_Data/Kentor.AuthServices.StubIdp.pfx" />
     </identityProvider>


### PR DESCRIPTION
Pro: This makes it easier to get the sample application started
Con: It is harder to understand the config file when the host name is not sensible
