### PR TITLE
Check for incorrect transforms in XML signature.

### DIFF
--- a/Kentor.AuthServices.Tests/Saml2ResponseTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2ResponseTests.cs
@@ -531,7 +531,7 @@ namespace Kentor.AuthServices.Tests
 
             var reference = new Reference { Uri = "#Saml2Response_Validate_FalseOnAdditionalTransformsInSignature" };
             reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
-            reference.AddTransform(new XmlDsigC14NTransform());
+            reference.AddTransform(new XmlDsigC14NTransform()); // The allowed transform is XmlDsigExcC14NTransform
             signedXml.AddReference(reference);
 
             signedXml.ComputeSignature();

--- a/Kentor.AuthServices/Saml2Response.cs
+++ b/Kentor.AuthServices/Saml2Response.cs
@@ -316,9 +316,9 @@ namespace Kentor.AuthServices
 
         private static readonly string[] allowedTransforms = new string[]
         {
-            "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
-            "http://www.w3.org/2001/10/xml-exc-c14n#",
-            "http://www.w3.org/2001/10/xml-exc-c14n#WithComments)"
+            SignedXml.XmlDsigEnvelopedSignatureTransformUrl,
+            SignedXml.XmlDsigExcC14NTransformUrl,
+            SignedXml.XmlDsigExcC14NWithCommentsTransformUrl
         };
 
         /// <summary>Checks the signature.</summary>
@@ -340,13 +340,15 @@ namespace Kentor.AuthServices
             signedXml.LoadXml(signature);
 
             var signedRootElementId = "#" + signedRootElement.GetAttribute("ID");
-            if (signedXml.SignedInfo.References.Count != 1 ||
-                signedXml.SignedInfo.References.Cast<Reference>().Single().Uri != signedRootElementId)
+
+            var reference = signedXml.SignedInfo.References.Cast<Reference>().FirstOrDefault();
+            
+            if (signedXml.SignedInfo.References.Count != 1 || reference.Uri != signedRootElementId)
             {
                 return false;
             }
 
-            foreach (Transform transform in ((Reference)signedXml.SignedInfo.References[0]).TransformChain)
+            foreach (Transform transform in reference.TransformChain)
             {
                 if (!allowedTransforms.Contains(transform.Algorithm))
                 {


### PR DESCRIPTION
- The SAML2 Core spec section 5.4.4 states what transforms are allowed, check that no others are used.
- Fixes #55.
