### PR TITLE
Add meta description to make Web Essentials happy

### DIFF
--- a/SampleMvcApplication/Views/Shared/_Layout.cshtml
+++ b/SampleMvcApplication/Views/Shared/_Layout.cshtml
@@ -6,6 +6,7 @@
     <title>@ViewBag.Title - My ASP.NET Application</title>
     @Styles.Render("~/Content/css")
     @Scripts.Render("~/bundles/modernizr")
+    <meta name="description" content="Sample application for how to use the MVC controller configuration for Kentor.Authservices" />
 </head>
 <body>
     <div class="navbar navbar-inverse navbar-fixed-top">


### PR DESCRIPTION
Fix Web Essentials warning by adding a meta description to the SampleMvcApplication
