### PR TITLE
Make ModulePath configurable via the application/web configuration file.

### DIFF
--- a/Kentor.AuthServices.Mvc/readme.txt
+++ b/Kentor.AuthServices.Mvc/readme.txt
@@ -28,7 +28,7 @@ Config Samples
   <section name="kentor.authServices" type="Kentor.AuthServices.Configuration.KentorAuthServicesSection, Kentor.AuthServices"/>
 </configSections>
 
-<kentor.authServices assertionConsumerServiceUrl="http://localhost:17009/SamplePath/Saml2AuthenticationModule/acs"
+<kentor.authServices assertionConsumerServiceUrl="http://localhost:17009/SamplePath/AuthServices/acs"
                             issuer="http://localhost:17009"
                             returnUri="http://localhost:17009/SamplePath/">
   <identityProvider issuer ="https://idp.example.com" destinationUri="httpss://idp.example.com" binding="HttpRedirect">

--- a/Kentor.AuthServices.Tests/Kentor.AuthServices.Tests.csproj
+++ b/Kentor.AuthServices.Tests/Kentor.AuthServices.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="CommandFactoryTests.cs" />
     <Compile Include="NotFoundCommandTests.cs" />
     <Compile Include="CommandResultTests.cs" />
+    <Compile Include="Saml2AuthenticationModuleTests.cs" />
     <Compile Include="Saml2RequestBaseTests.cs" />
     <Compile Include="Saml2AuthenticationRequestTests.cs" />
     <Compile Include="IdentityProviderTests.cs" />

--- a/Kentor.AuthServices.Tests/Saml2AuthenticationModuleTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2AuthenticationModuleTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+using System.Xml.Linq;
+using System.IdentityModel.Tokens;
+using System.Xml;
+using Kentor.AuthServices.Configuration;
+
+namespace Kentor.AuthServices.Tests
+{
+    [TestClass]
+    public class Saml2AuthenticationModuleTests
+    {
+        [TestMethod]
+        public void ModulePath_Can_Be_Configured()
+        {
+          var modulePath = "~/MyCustomAuthSequence";
+          KentorAuthServicesSection.Current.ModulePath = modulePath;
+
+          var x = Saml2AuthenticationModule.ModulePath;
+          x.Should().Be(modulePath);
+        }
+        
+        [TestMethod]
+        public void ModulePath_Is_Default_When_Not_Specified()
+        {
+            // Ensure that the value is non-existent
+            KentorAuthServicesSection.Current.ModulePath = null;
+
+            var x = Saml2AuthenticationModule.ModulePath;
+          
+            x.Should().Be("~/AuthServices");
+        }
+    }
+}

--- a/Kentor.AuthServices.Tests/Saml2AuthenticationRequestTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2AuthenticationRequestTests.cs
@@ -34,8 +34,8 @@ namespace Kentor.AuthServices.Tests
         [TestMethod]
         public void Saml2AuthenticationRequest_AssertionConsumerServiceUrl()
         {
-            string url = "http://some.example.com/Saml2AuthenticationModule/acs";
-            var x = new Saml2AuthenticationRequest()
+            string url = "http://some.example.com/AuthServices/acs";
+            var x = new Saml2AuthenticationRequest() 
             {
                 AssertionConsumerServiceUrl = new Uri(url)
             }.ToXElement();

--- a/Kentor.AuthServices/Configuration/KentorAuthServicesSection.cs
+++ b/Kentor.AuthServices/Configuration/KentorAuthServicesSection.cs
@@ -12,8 +12,10 @@ namespace Kentor.AuthServices.Configuration
     /// </summary>
     public class KentorAuthServicesSection : ConfigurationSection
     {
-        private static readonly KentorAuthServicesSection current = 
-            (KentorAuthServicesSection)ConfigurationManager.GetSection("kentor.authServices");
+        private string modulePath;
+
+        private static readonly KentorAuthServicesSection current =
+        (KentorAuthServicesSection)ConfigurationManager.GetSection("kentor.authServices");
 
         /// <summary>
         /// Current config as read from app/web.config.
@@ -24,6 +26,26 @@ namespace Kentor.AuthServices.Configuration
             {
                 return current;
             }
+        }
+
+        /// <summary>
+        /// Base Uri for where requests will be intercepted and processed for auth services. 
+        /// </summary>
+        [ConfigurationProperty("modulePath")]
+        public string ModulePath
+        {
+          get
+          {
+              if (modulePath != null) 
+              {
+                  return (modulePath);
+              }
+              return (modulePath = (! String.IsNullOrEmpty((string) base["modulePath"]) ? (string) base["modulePath"] : "~/AuthServices"));
+          }
+          internal set // marked internal for testing only.
+          {
+              modulePath = value;
+          }
         }
 
         /// <summary>

--- a/Kentor.AuthServices/Saml2AuthenticationModule.cs
+++ b/Kentor.AuthServices/Saml2AuthenticationModule.cs
@@ -5,18 +5,30 @@ using System.IdentityModel.Tokens;
 using System.Linq;
 using System.Net;
 using System.Web;
+using Kentor.AuthServices.Configuration;
 
 namespace Kentor.AuthServices
 {
     /// <summary>
     /// Http Module for SAML2 authentication. The module hijacks the 
-    /// ~/Saml2AuthenticationModule/ path of the http application to provide 
-    /// authentication services.
+    /// configurable ~/AuthServices path of the http application to provide 
+    /// authentication services. 
     /// </summary>
     // Not included in code coverage as the http module is tightly dependent on IIS.
     [ExcludeFromCodeCoverage]
     public class Saml2AuthenticationModule : IHttpModule
     {
+        /// <summary>
+        /// Base Uri for where requests will be intercepted and processed for auth services. 
+        /// </summary>
+        public static string ModulePath 
+        {
+            get
+            {
+                return KentorAuthServicesSection.Current.ModulePath;
+            }
+        }
+
         /// <summary>
         /// Init the module and subscribe to events.
         /// </summary>
@@ -30,10 +42,9 @@ namespace Kentor.AuthServices
             context.BeginRequest += OnBeginRequest;
         }
 
-        const string ModulePath = "~/Saml2AuthenticationModule/";
-
         /// <summary>
-        /// Begin request handler that captures all traffic to ~/Saml2AuthenticationModule/
+        /// Begin request handler that captures all traffic to ~/AuthServices/
+        /// or the configured <seealso cref="ModulePath" />.
         /// </summary>
         /// <param name="sender">The http application.</param>
         /// <param name="e">Ignored</param>

--- a/Kentor.AuthServices/readme.txt
+++ b/Kentor.AuthServices/readme.txt
@@ -35,7 +35,7 @@ Config Samples
   </httpModules>
 </system.web>
 
-<kentor.authServices assertionConsumerServiceUrl="http://localhost:17009/SamplePath/Saml2AuthenticationModule/acs"
+<kentor.authServices assertionConsumerServiceUrl="http://localhost:17009/SamplePath/AuthServices/acs"
                             issuer="http://localhost:17009"
                             returnUri="http://localhost:17009/SamplePath/">
   <identityProvider issuer ="https://idp.example.com" destinationUri="httpss://idp.example.com" binding="HttpRedirect">

--- a/SampleApplication/Views/Home/Index.cshtml
+++ b/SampleApplication/Views/Home/Index.cshtml
@@ -1,5 +1,6 @@
 ﻿@{
     ViewBag.Title = "Home";
+    string modulePath = ViewBag.ModulePath ?? Kentor.AuthServices.Configuration.KentorAuthServicesSection.Current.ModulePath;
 }
 
 <h1>Sample Saml2 Authentication Application</h1>
@@ -13,38 +14,38 @@
         You are currently not signed in.
     </p>
     <p>
-        <a href="@Url.Content("~/Saml2AuthenticationModule/SignIn")">Sign in</a> - default IDP
+        <a href="@Url.Content(String.Format("~/{0}/SignIn", modulePath))">Sign in</a> - default IDP
         @foreach (var idp in Kentor.AuthServices.Configuration.KentorAuthServicesSection.Current.IdentityProviders)
         {
             var issuer = idp.Issuer;
             var destinationUri = idp.DestinationUri;
             <br />
-            <a href="@Url.Content("~/Saml2AuthenticationModule/SignIn?issuer=" + HttpUtility.UrlEncode(issuer))">Sign in</a>@: - @issuer - @destinationUri
+            <a href="@Url.Content(String.Format("~/{0}/SignIn?issuer={1}", modulePath, HttpUtility.UrlEncode(issuer)))">Sign in</a>@: - @issuer - @destinationUri
         }
-    </p>
-}
-else
-{
-    <p>
-        You are signed in. <a href="@Url.Action("SignOut")">Sign out</a>.
-    </p>
-    <table>
-        <thead>
-            <tr>
-                <th>Claim Type</th>
-                <th>Claim Value</th>
-                <th>Issuer</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var c in System.Security.Claims.ClaimsPrincipal.Current.Claims)
+</p>
+        }
+        else
+        {
+<p>
+    You are signed in. <a href="@Url.Action("SignOut")">Sign out</a>.
+</p>
+<table>
+    <thead>
+        <tr>
+            <th>Claim Type</th>
+            <th>Claim Value</th>
+            <th>Issuer</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var c in System.Security.Claims.ClaimsPrincipal.Current.Claims)
             {
-                <tr>
-                    <td>@c.Type</td>
-                    <td>@c.Value</td>
-                    <td>@c.Issuer</td>
-                </tr>                
+            <tr>
+                <td>@c.Type</td>
+                <td>@c.Value</td>
+                <td>@c.Issuer</td>
+            </tr>
             }
-        </tbody>
-    </table>
-}
+    </tbody>
+</table>
+        }


### PR DESCRIPTION
See issue #86.

Add modulePath="" attribute to kentor.authServices configuration. If not specified, defaults to "~/AuthServices".

With this change, I believe that the assertionConsumerServiceUrl parameter can be removed and generated dynamically. Although I don't see the need, I suppose we could leave the assertionConsumerServiceUrl  attribute and just dynamically generate the value from the modulePath value if it wasn't configured or explicitly defined. A consumer could always override the default.

Taking it to the next step, the /acs portion of the Url could also be generated by the CommandFactory dictionary. Same could apply to the /signup and forthcoming /metadata commands.
