### PR TITLE
Extended handler configuration and issuer token validation support

### DIFF
--- a/Kentor.AuthServices.TestHelpers/SignedXmlHelper.cs
+++ b/Kentor.AuthServices.TestHelpers/SignedXmlHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System.Security.Cryptography.X509Certificates;
 using System.Xml;
-using Kentor.AuthServices;
 using System.Security.Cryptography.Xml;
 using System.Security.Cryptography;
 
@@ -22,6 +21,16 @@ namespace Kentor.AuthServices.TestHelpers
             return xmlDoc.OuterXml;
         }
 
+        public static XmlDocument SignAssertionXml(string xml)
+        {
+            var xmlDoc = new XmlDocument { PreserveWhitespace = false };
+            xmlDoc.LoadXml(xml);
+
+            SignAssertion(xmlDoc, TestCert);
+
+            return xmlDoc;
+        }
+
         public static readonly string KeyInfoXml;
 
         static SignedXmlHelper()
@@ -30,6 +39,38 @@ namespace Kentor.AuthServices.TestHelpers
             keyInfo.AddClause(new KeyInfoX509Data(TestCert));
 
             KeyInfoXml = keyInfo.GetXml().OuterXml;
+        }
+
+        private static void SignAssertion(XmlDocument xmlDocument, X509Certificate2 cert)
+        {            
+            var signedXml = new SignedXml(xmlDocument);
+
+            // The transform XmlDsigExcC14NTransform and canonicalization method XmlDsigExcC14NTransformUrl is important for partially signed XML files
+            // see: http://msdn.microsoft.com/en-us/library/system.security.cryptography.xml.signedxml.xmldsigexcc14ntransformurl(v=vs.110).aspx
+            // The reference URI has to be set correctly to avoid assertion injections
+            // For both, the ID/Reference and the Transform/Canonicalization see as well: 
+            // https://www.oasis-open.org/committees/download.php/35711/sstc-saml-core-errata-2.0-wd-06-diff.pdf section 5.4.2 and 5.4.3
+
+            signedXml.SigningKey = cert.PrivateKey;
+            signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
+
+            var reference = new Reference { Uri = "#" + xmlDocument.DocumentElement.GetAttribute("ID") };
+            reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
+            reference.AddTransform(new XmlDsigExcC14NTransform());
+
+            signedXml.AddReference(reference);
+
+
+            // Include the public key of the certificate in the assertion.
+            signedXml.KeyInfo = new KeyInfo();
+            signedXml.KeyInfo.AddClause(new KeyInfoX509Data(cert, X509IncludeOption.WholeChain));
+
+            signedXml.ComputeSignature();              
+
+            // Append the computed signature. The signature must be placed as the sibling of the Issuer element.
+            var nodes = xmlDocument.DocumentElement.GetElementsByTagName("Issuer", Saml2Namespaces.Saml2.NamespaceName);            
+
+            xmlDocument.DocumentElement.InsertAfter(xmlDocument.ImportNode(signedXml.GetXml(), true), nodes[0]);     
         }
     }
 }

--- a/Kentor.AuthServices/SAML2P/Saml2PSecurityTokenHandler.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2PSecurityTokenHandler.cs
@@ -1,8 +1,6 @@
-﻿using Kentor.AuthServices.Configuration;
-using Kentor.AuthServices.Internal;
+﻿using Kentor.AuthServices.Internal;
 using System;
 using System.IdentityModel.Metadata;
-using System.IdentityModel.Selectors;
 using System.IdentityModel.Services;
 using System.IdentityModel.Tokens;
 using System.Security.Claims;
@@ -31,15 +29,25 @@ namespace Kentor.AuthServices.Saml2P
                 throw new ArgumentNullException("spEntityId");
             }
 
-            var audienceRestriction = new AudienceRestriction(AudienceUriMode.Always);
-            audienceRestriction.AllowedAudienceUris.Add(
+            FederatedAuthentication.FederationConfiguration.IdentityConfiguration.AudienceRestriction.AllowedAudienceUris.Add(
                 new Uri(spEntityId.Id));
+
+            if (FederatedAuthentication.FederationConfiguration.IdentityConfiguration.IssuerNameRegistry is ConfigurationBasedIssuerNameRegistry
+                &&
+                (FederatedAuthentication.FederationConfiguration.IdentityConfiguration.IssuerNameRegistry as
+                    ConfigurationBasedIssuerNameRegistry).ConfiguredTrustedIssuers.Count == 0)
+            {
+                FederatedAuthentication.FederationConfiguration.IdentityConfiguration.IssuerNameRegistry =
+                    new ReturnRequestedIssuerNameRegistry();
+            }
 
             Configuration = new SecurityTokenHandlerConfiguration
             {
-                IssuerNameRegistry = new ReturnRequestedIssuerNameRegistry(),
-                AudienceRestriction = audienceRestriction,
-                SaveBootstrapContext = FederatedAuthentication.FederationConfiguration.IdentityConfiguration.SaveBootstrapContext
+                IssuerNameRegistry = FederatedAuthentication.FederationConfiguration.IdentityConfiguration.IssuerNameRegistry,
+                AudienceRestriction = FederatedAuthentication.FederationConfiguration.IdentityConfiguration.AudienceRestriction,
+                SaveBootstrapContext = FederatedAuthentication.FederationConfiguration.IdentityConfiguration.SaveBootstrapContext,
+                CertificateValidator = FederatedAuthentication.FederationConfiguration.IdentityConfiguration.CertificateValidator,
+                CertificateValidationMode = FederatedAuthentication.FederationConfiguration.IdentityConfiguration.CertificateValidationMode
             };
         }
 


### PR DESCRIPTION
Add support for  <securityTokenHandlerConfiguration>  configurations:
•audienceUris
•certificateValidation
•certificateValidationMode
•issuerNameRegistry

http://msdn.microsoft.com/en-us/library/hh568639(v=vs.110).aspx

Add support for token issuer certificate validation base on the handler configuration
