### PR TITLE
Correct handling of validUntil and cacheDuration

### DIFF
--- a/Kentor.AuthServices.Tests/IdentityProviderTests.cs
+++ b/Kentor.AuthServices.Tests/IdentityProviderTests.cs
@@ -455,8 +455,8 @@ namespace Kentor.AuthServices.Tests
 
             var subject = new IdentityProvider(config, Options.FromConfiguration.SPOptions);
 
-            var expectedValidUntil = DateTime.UtcNow.AddMinutes(15);
-            // Comparison on the second is more than enough if we're adding 15 minutes.
+            var expectedValidUntil = DateTime.UtcNow.AddHours(1);
+            // Comparison on the second is more than enough if we're adding 1 hour.
             subject.MetadataValidUntil.Should().BeCloseTo(expectedValidUntil, 1000);
         }
 
@@ -753,8 +753,7 @@ namespace Kentor.AuthServices.Tests
             // If a metadatalocation is set, metadata loading is automatically enabled.
             subject.LoadMetadata.Should().BeTrue();
             subject.MetadataLocation.Should().Be("http://localhost:13428/idpMetadataOtherEntityId");
-            subject.MetadataValidUntil.Should().BeCloseTo(
-                DateTime.UtcNow.Add(MetadataRefreshScheduler.DefaultMetadataCacheDuration), precision: 100);
+            subject.MetadataValidUntil.Should().BeCloseTo(DateTime.UtcNow.AddDays(1), precision: 100);
             subject.SingleSignOnServiceUrl.Should().Be("http://wrong.entityid.example.com/acs");
             subject.WantAuthnRequestsSigned.Should().Be(true, "WantAuthnRequestsSigned should have been loaded from metadata");
 

--- a/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
+++ b/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
@@ -126,6 +126,30 @@ namespace Kentor.AuthServices.Tests.Metadata
         }
 
         [TestMethod]
+        public void MetadataRefreshScheduler_CalculateMetadataCacheDuration_ShortValidUntil_CacheDurationMissing()
+        {
+            var metadata = Substitute.For<ICachedMetadata>();
+            metadata.ValidUntil = DateTime.UtcNow.AddMinutes(3);
+            metadata.CacheDuration = null;
+
+            var subject = metadata.CalculateMetadataCacheDuration();
+
+            subject.Should().BeCloseTo(new TimeSpan(0, 2, 0));
+        }
+
+        [TestMethod]
+        public void MetadataRefreshScheduler_CalculateMetadataCacheDuration_LongValidUntil_CacheDurationMissing()
+        {
+            var metadata = Substitute.For<ICachedMetadata>();
+            metadata.ValidUntil = DateTime.UtcNow.AddHours(12);
+            metadata.CacheDuration = null;
+
+            var subject = metadata.CalculateMetadataCacheDuration();
+
+            subject.Should().Be(MetadataRefreshScheduler.DefaultMetadataCacheDuration);
+        }
+
+        [TestMethod]
         public void MetadataRefreshScheduler_CalculateMetadataCacheDuration_ValidUntilMissing_CacheDurationMissing()
         {
             var metadata = Substitute.For<ICachedMetadata>();

--- a/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
+++ b/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
@@ -86,7 +86,7 @@ namespace Kentor.AuthServices.Tests.Metadata
 
             var subject = metadata.CalculateMetadataValidUntil();
 
-            subject.Should().BeCloseTo(DateTime.UtcNow.AddDays(1), precision: 100);            
+            subject.Should().BeCloseTo(DateTime.UtcNow.AddDays(1), precision: 100);
         }
 
         [TestMethod]

--- a/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
+++ b/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
@@ -12,9 +12,10 @@ namespace Kentor.AuthServices.Tests.Metadata
         [TestMethod]
         public void MetadataRefreshScheduler_GetDelay_ReturnsHalfRemaining()
         {
-            var validUntil = DateTime.UtcNow.AddHours(2);
+            var cacheDuration = new TimeSpan(2, 0, 0);
+            var cacheDurationExpiryDate = DateTime.UtcNow.Add(cacheDuration);
 
-            var subject = MetadataRefreshScheduler.GetDelay(validUntil);
+            var subject = MetadataRefreshScheduler.GetDelay(cacheDurationExpiryDate);
 
             subject.Should().BeCloseTo(new TimeSpan(1, 0, 0));
         }
@@ -22,9 +23,10 @@ namespace Kentor.AuthServices.Tests.Metadata
         [TestMethod]
         public void MetadataRefreshScheduler_GetDelay_RespectsMinInterval()
         {
-            var validUntil = DateTime.UtcNow.AddSeconds(10);
+            var cacheDuration = new TimeSpan(0, 0, 10);
+            var cacheDurationExpiryDate = DateTime.UtcNow.Add(cacheDuration);
 
-            var subject = MetadataRefreshScheduler.GetDelay(validUntil);
+            var subject = MetadataRefreshScheduler.GetDelay(cacheDurationExpiryDate);
 
             subject.Should().BeCloseTo(new TimeSpan(0, 1, 0));
         }
@@ -32,9 +34,9 @@ namespace Kentor.AuthServices.Tests.Metadata
         [TestMethod]
         public void MetadataRefreshScheduler_GetDelay_RespectsMaxInterval()
         {
-            var validUntil = new DateTime(2100, 01, 01);
+            var cacheDurationExpiryDate = new DateTime(2100, 01, 01);
 
-            var subject = MetadataRefreshScheduler.GetDelay(validUntil);
+            var subject = MetadataRefreshScheduler.GetDelay(cacheDurationExpiryDate);
 
             var maxDelay = new TimeSpan(0, 0, 0, 0, int.MaxValue);
 
@@ -42,13 +44,99 @@ namespace Kentor.AuthServices.Tests.Metadata
         }
 
         [TestMethod]
-        public void MetadataRefreshScheduler_CalculateMetadataValidUntil_DefaultValue()
+        public void MetadataRefreshScheduler_CalculateMetadataValidUntil_ValidUntilExists_CacheDurationExists()
         {
             var metadata = Substitute.For<ICachedMetadata>();
+            metadata.ValidUntil = new DateTime(2100, 01, 01);
+            metadata.CacheDuration = MetadataRefreshScheduler.DefaultMetadataCacheDuration;
 
             var subject = metadata.CalculateMetadataValidUntil();
 
-            subject.Should().BeCloseTo(DateTime.UtcNow.AddHours(1));
+            subject.Should().Be(new DateTime(2100, 01, 01));
+        }
+
+        [TestMethod]
+        public void MetadataRefreshScheduler_CalculateMetadataValidUntil_ValidUntilMissing_CacheDurationExists()
+        {
+            var metadata = Substitute.For<ICachedMetadata>();
+            metadata.CacheDuration = MetadataRefreshScheduler.DefaultMetadataCacheDuration;
+            metadata.ValidUntil = null;
+
+            var subject = metadata.CalculateMetadataValidUntil();
+
+            subject.Should().BeCloseTo(DateTime.UtcNow.AddHours(4));
+        }
+
+        [TestMethod]
+        public void MetadataRefreshScheduler_CalculateMetadataValidUntil_ValidUntilExists_CacheDurationMissing()
+        {
+            var metadata = Substitute.For<ICachedMetadata>();
+            metadata.ValidUntil = new DateTime(2100, 01, 01);
+            metadata.CacheDuration = null;
+
+            var subject = metadata.CalculateMetadataValidUntil();
+
+            subject.Should().Be(new DateTime(2100, 01, 01));
+        }
+
+        [TestMethod]
+        public void MetadataRefreshScheduler_CalculateMetadataValidUntil_ValidUntilMissing_CacheDurationMissing()
+        {
+            var metadata = Substitute.For<ICachedMetadata>();
+            metadata.ValidUntil = null;
+            metadata.CacheDuration = null;
+
+            var subject = metadata.CalculateMetadataValidUntil();
+
+            subject.Should().BeCloseTo(DateTime.UtcNow.AddDays(1), precision: 100);            
+        }
+
+        [TestMethod]
+        public void MetadataRefreshScheduler_CalculateMetadataCacheDuration_ValidUntilExists_CacheDurationExists()
+        {
+            var metadata = Substitute.For<ICachedMetadata>();
+            metadata.ValidUntil = new DateTime(2100, 01, 01);
+            metadata.CacheDuration = MetadataRefreshScheduler.DefaultMetadataCacheDuration;
+
+            var subject = metadata.CalculateMetadataCacheDuration();
+
+            subject.Should().Be(new TimeSpan(1, 0, 0));
+        }
+
+        [TestMethod]
+        public void MetadataRefreshScheduler_CalculateMetadataCacheDuration_ValidUntilMissing_CacheDurationExists()
+        {
+            var metadata = Substitute.For<ICachedMetadata>();
+            metadata.ValidUntil = null;
+            metadata.CacheDuration = MetadataRefreshScheduler.DefaultMetadataCacheDuration;
+
+            var subject = metadata.CalculateMetadataCacheDuration();
+
+            subject.Should().Be(new TimeSpan(1, 0, 0));
+        }
+
+        [TestMethod]
+        public void MetadataRefreshScheduler_CalculateMetadataCacheDuration_ValidUntilExists_CacheDurationMissing()
+        {
+            var metadata = Substitute.For<ICachedMetadata>();
+            metadata.ValidUntil = DateTime.UtcNow.AddHours(1);
+            metadata.CacheDuration = null;
+
+            var subject = metadata.CalculateMetadataCacheDuration();
+
+            subject.Should().BeCloseTo(new TimeSpan(0, 15, 0));
+        }
+
+        [TestMethod]
+        public void MetadataRefreshScheduler_CalculateMetadataCacheDuration_ValidUntilMissing_CacheDurationMissing()
+        {
+            var metadata = Substitute.For<ICachedMetadata>();
+            metadata.ValidUntil = null;
+            metadata.CacheDuration = null;
+
+            var subject = metadata.CalculateMetadataCacheDuration();
+
+            subject.Should().Be(new TimeSpan(1, 0, 0));
         }
     }
 }

--- a/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
+++ b/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
@@ -57,8 +57,8 @@ namespace Kentor.AuthServices.Tests.Metadata
         public void MetadataRefreshScheduler_CalculateMetadataValidUntil_ValidUntilMissing_CacheDurationExists()
         {
             var metadata = Substitute.For<ICachedMetadata>();
-            metadata.CacheDuration = MetadataRefreshScheduler.DefaultMetadataCacheDuration;
             metadata.ValidUntil = null;
+            metadata.CacheDuration = MetadataRefreshScheduler.DefaultMetadataCacheDuration;            
 
             var subject = metadata.CalculateMetadataValidUntil();
 

--- a/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
+++ b/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
@@ -12,10 +12,9 @@ namespace Kentor.AuthServices.Tests.Metadata
         [TestMethod]
         public void MetadataRefreshScheduler_GetDelay_ReturnsHalfRemaining()
         {
-            var cacheDuration = new TimeSpan(2, 0, 0);
-            var cacheDurationExpiryDate = DateTime.UtcNow.Add(cacheDuration);
+            var validUntil = DateTime.UtcNow.AddHours(2);
 
-            var subject = MetadataRefreshScheduler.GetDelay(cacheDurationExpiryDate);
+            var subject = MetadataRefreshScheduler.GetDelay(validUntil);
 
             subject.Should().BeCloseTo(new TimeSpan(1, 0, 0));
         }
@@ -23,10 +22,9 @@ namespace Kentor.AuthServices.Tests.Metadata
         [TestMethod]
         public void MetadataRefreshScheduler_GetDelay_RespectsMinInterval()
         {
-            var cacheDuration = new TimeSpan(0, 0, 10);
-            var cacheDurationExpiryDate = DateTime.UtcNow.Add(cacheDuration);
+            var validUntil = DateTime.UtcNow.AddSeconds(10);
 
-            var subject = MetadataRefreshScheduler.GetDelay(cacheDurationExpiryDate);
+            var subject = MetadataRefreshScheduler.GetDelay(validUntil);
 
             subject.Should().BeCloseTo(new TimeSpan(0, 1, 0));
         }
@@ -34,9 +32,9 @@ namespace Kentor.AuthServices.Tests.Metadata
         [TestMethod]
         public void MetadataRefreshScheduler_GetDelay_RespectsMaxInterval()
         {
-            var cacheDurationExpiryDate = new DateTime(2100, 01, 01);
+            var validUntil = new DateTime(2100, 01, 01);
 
-            var subject = MetadataRefreshScheduler.GetDelay(cacheDurationExpiryDate);
+            var subject = MetadataRefreshScheduler.GetDelay(validUntil);
 
             var maxDelay = new TimeSpan(0, 0, 0, 0, int.MaxValue);
 

--- a/Kentor.AuthServices/Metadata/MetadataRefreshScheduler.cs
+++ b/Kentor.AuthServices/Metadata/MetadataRefreshScheduler.cs
@@ -33,33 +33,36 @@ namespace Kentor.AuthServices.Metadata
 
         internal static TimeSpan CalculateMetadataCacheDuration(this ICachedMetadata metadata)
         {
-            if ((metadata.ValidUntil.HasValue && metadata.CacheDuration.HasValue) ||
-                (!metadata.ValidUntil.HasValue && metadata.CacheDuration.HasValue))
+            if (metadata.CacheDuration.HasValue)
             {
                 return (TimeSpan)metadata.CacheDuration;
             }
 
-            if (metadata.ValidUntil.HasValue && !metadata.CacheDuration.HasValue)
+            if (metadata.ValidUntil.HasValue)
             {
-                var timeRemaining = metadata.ValidUntil.Value - DateTime.UtcNow;
-                var twoMinutes = new TimeSpan(0, 2, 0).Ticks;
-                return new TimeSpan(Math.Max(Math.Min(DefaultMetadataCacheDuration.Ticks, timeRemaining.Ticks / 4), twoMinutes));
+                return CalculateCacheDurationFromValidUntil(metadata.ValidUntil.Value);
             }
 
             return DefaultMetadataCacheDuration;
+        }
+
+        private static TimeSpan CalculateCacheDurationFromValidUntil(DateTime validUntil)
+        {
+            var timeRemaining = validUntil - DateTime.UtcNow;
+            var twoMinutes = new TimeSpan(0, 2, 0).Ticks;
+            return new TimeSpan(Math.Max(Math.Min(DefaultMetadataCacheDuration.Ticks, timeRemaining.Ticks / 4), twoMinutes));
         }
 
         public static readonly TimeSpan DefaultMetadataCacheDuration = new TimeSpan(1, 0, 0);
 
         internal static DateTime CalculateMetadataValidUntil(this ICachedMetadata metadata)
         {
-            if ((metadata.ValidUntil.HasValue && metadata.CacheDuration.HasValue) ||
-                (metadata.ValidUntil.HasValue && !metadata.CacheDuration.HasValue))
+            if (metadata.ValidUntil.HasValue)
             {
                 return (DateTime)metadata.ValidUntil;
             }
 
-            if (!metadata.ValidUntil.HasValue && metadata.CacheDuration.HasValue)
+            if (metadata.CacheDuration.HasValue)
             {
                 var extendedCacheDuration = metadata.CacheDuration.Value.Ticks * 4;
                 return DateTime.UtcNow.Add(new TimeSpan(extendedCacheDuration));

--- a/Kentor.AuthServices/WebSSO/HttpRequestData.cs
+++ b/Kentor.AuthServices/WebSSO/HttpRequestData.cs
@@ -51,7 +51,7 @@ namespace Kentor.AuthServices.WebSso
         /// <param name="cookies">Cookies of request</param>
         /// <param name="cookieDecryptor">Function that decrypts cookie
         /// contents to clear text.</param>
-        /// <param name="user">Claims Principal associated with the request
+        /// <param name="user">Claims Principal associated with the request</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Decryptor")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         public HttpRequestData(


### PR DESCRIPTION
Pull request to get access to build server and verify code coverage for the new method.
- Added new method CalculateMetadataCacheDuration.
- Updated existing method CalculateMetadataValidUntil.
- Added and modified unit tests where needed.

Values for cacheDuration and validUntil are now calculated as follows:
- If validUntil and cacheDuration exists, respective values are returned.
- If validUntil is missing and cacheDuration exists, validUntil is set to cacheDuration \* 4.
- If validUntil exist and cacheDuration is missing, cacheDuration is determined according to the formula max(min(1h, (validUntil - now) / 4), 2 min).
- If values for both validUntil and cacheDuration are missing in metadata, validUntil is set to 24h and cacheDuration is set to 1h.
