### PR TITLE
Add ability to sign assertion

### DIFF
--- a/Kentor.AuthServices.Tests/Saml2P/Saml2ResponseTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2P/Saml2ResponseTests.cs
@@ -1281,6 +1281,41 @@ namespace Kentor.AuthServices.Tests.Saml2P
         }
 
         [TestMethod]
+        public void Saml2Response_GetClaims_UsingSignedAssertionsFlag_WithSingleAssertion()
+        {
+            var identity = new ClaimsIdentity(new Claim[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "JohnDoe")
+            });
+
+            var response = new Saml2Response(new EntityId("https://idp.example.com"), SignedXmlHelper.TestCert,
+                new Uri("http://destination.example.com"), null, null, null, true, identity);
+
+            Action a = () => Saml2Response.Read(response.ToXml()).GetClaims(Options.FromConfiguration);
+            a.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void Saml2Response_GetClaims_UsingSignedAssertionsFlag_WithMultipleAssertions()
+        {
+            var identity1 = new ClaimsIdentity(new Claim[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "JohnDoe")
+            });
+
+            var identity2 = new ClaimsIdentity(new Claim[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "JaneDoe")
+            });
+
+            var response = new Saml2Response(new EntityId("https://idp.example.com"), SignedXmlHelper.TestCert,
+                new Uri("http://destination.example.com"), null, null, null, true, identity1, identity2);
+
+            Action a = () => Saml2Response.Read(response.ToXml()).GetClaims(Options.FromConfiguration);
+            a.ShouldNotThrow();
+        }
+
+        [TestMethod]
         public void Saml2Response_Read_ThrowsOnIncorrectInResponseTo()
         {
             var idp = Options.FromConfiguration.IdentityProviders.Default;

--- a/Kentor.AuthServices/WebSSO/Saml2PostBinding.cs
+++ b/Kentor.AuthServices/WebSSO/Saml2PostBinding.cs
@@ -65,6 +65,13 @@ namespace Kentor.AuthServices.WebSso
                 };
 
                 xmlDoc.LoadXml(xml);
+
+                var assertionElement = xmlDoc.SelectSingleNode(@"//*[local-name()='Response']/*[local-name()='Assertion']") as XmlElement;
+                if (assertionElement != null)
+                {
+                    assertionElement.Sign(message.SigningCertificate, true);
+                }
+
                 xmlDoc.Sign(message.SigningCertificate, true);
                 xml = xmlDoc.OuterXml;
             }

--- a/Kentor.AuthServices/WebSSO/Saml2PostBinding.cs
+++ b/Kentor.AuthServices/WebSSO/Saml2PostBinding.cs
@@ -65,13 +65,6 @@ namespace Kentor.AuthServices.WebSso
                 };
 
                 xmlDoc.LoadXml(xml);
-
-                var assertionElement = xmlDoc.SelectSingleNode(@"//*[local-name()='Response']/*[local-name()='Assertion']") as XmlElement;
-                if (assertionElement != null)
-                {
-                    assertionElement.Sign(message.SigningCertificate, true);
-                }
-
                 xmlDoc.Sign(message.SigningCertificate, true);
                 xml = xmlDoc.OuterXml;
             }


### PR DESCRIPTION
I came across a requirement where the assertion needed to be signed in addition to the response. The proposed change seems to successfully meet the requirement. I think ideally it should be optional but didn't see an easy way to do that. I'm open to any suggestions.
