### PR TITLE
use relayState as returnUrl for acs response

### DIFF
--- a/Kentor.AuthServices.Tests/Kentor.AuthServices.Tests.csproj
+++ b/Kentor.AuthServices.Tests/Kentor.AuthServices.Tests.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Saml2P\FilteringXmlNodeReaderTests.cs" />
     <Compile Include="Exceptions\Saml2ResponseFailedValidationExceptionTests.cs" />
     <Compile Include="StoredRequestStateTests.cs" />
+    <Compile Include="UrlExtensionsTests.cs" />
     <Compile Include="WebSSO\HttpRequestDataTests.cs" />
     <Compile Include="WebSSO\Saml2ArtifactBindingTests.cs" />
     <Compile Include="WebSSO\Saml2MessageImplementation.cs" />

--- a/Kentor.AuthServices.Tests/UrlExtensionsTests.cs
+++ b/Kentor.AuthServices.Tests/UrlExtensionsTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Kentor.AuthServices.Tests
+{
+    [TestClass]
+    public class UrlExtensionsTests
+    {
+        [TestMethod]
+        public void UrlExtensions_AppendReturnUrl_NullBaseUrl_ShouldReturns_Null()
+        {
+            var actual = UrlExtensions.AppendReturnUrl(null, "http://foo.com");
+            
+            actual.Should().Be(null);
+        }
+
+        [TestMethod]
+        public void UrlExtensions_AppendReturnUrl_NullReturnUrl_ShouldReturns_BaseUrl()
+        {
+            var expected = new Uri("https://test.com");
+            var actual = expected.AppendReturnUrl(null);
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void UrlExtensions_AppendReturnUrl_EmptyReturnUrl_ShouldReturns_BaseUrl()
+        {
+            var expected = new Uri("https://test.com");
+            var actual = expected.AppendReturnUrl(string.Empty);
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void UrlExtensions_AppendReturnUrl_InvalidReturnUrl_ShouldReturns_BaseUrl()
+        {
+            var expected = new Uri("https://test.com");
+            var url = new Uri("https://test.com");
+            var actual = url.AppendReturnUrl("https:// foo.com/news");
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void UrlExtensions_AppendReturnUrl_NotEncodedReturnUrl_ShouldReturns_ModifedBaseUrl()
+        {
+            var expected = new Uri("https://test.com?returnUrl=https://foo.com/news");
+            var url = new Uri("https://test.com");
+            var actual = url.AppendReturnUrl("https://foo.com/news");
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void UrlExtensions_AppendReturnUrl_NotEncodedReturnUrl_WithPort_ShouldReturns_ModifedBaseUrl()
+        {
+            var expected = new Uri("https://test.com:443?returnUrl=https://foo.com/news");
+            var url = new Uri("https://test.com:443");
+            var actual = url.AppendReturnUrl("https://foo.com/news");
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void UrlExtensions_AppendReturnUrl_NotEncodedReturnUrl_AddToQuery_ShouldReturns_ModifedBaseUrl()
+        {
+            var expected = new Uri("https://test.com?q1=test&returnUrl=https://foo.com/news");
+            var url = new Uri("https://test.com?q1=test");
+            var actual = url.AppendReturnUrl("https://foo.com/news");
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void UrlExtensions_GetReturnUrlWithResourcePath_EncodedReturnUrl_ShouldReturns_ModifedBaseUrl()
+        {
+            var expected = new Uri("https://test.com?returnUrl=https://foo.com/news");
+            var url = new Uri("https://test.com");
+            var actual = url.AppendReturnUrl(Uri.EscapeUriString("https://foo.com/news"));
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void ReturnUrlExtensions_GetReturnUrlWithResourcePath_EncodedReturnUrl_WithPort_ShouldReturns_ModifedBaseUrl()
+        {
+            var expected = new Uri("https://test.com:443?returnUrl=https://foo.com/news");
+            var url = new Uri("https://test.com:443");
+            var actual = url.AppendReturnUrl(Uri.EscapeUriString("https://foo.com/news"));
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void UrlExtensions_GetReturnUrlWithResourcePath_EncodedReturnUrl_AddToQuery_ShouldReturns_ModifedBaseUrl()
+        {
+            var expected = new Uri("https://test.com?q1=test&returnUrl=https://foo.com/news");
+            var url = new Uri("https://test.com?q1=test");
+            var actual = url.AppendReturnUrl(Uri.EscapeUriString("https://foo.com/news "));
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/Kentor.AuthServices/Kentor.AuthServices.csproj
+++ b/Kentor.AuthServices/Kentor.AuthServices.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Internal\StringHelpers.cs" />
     <Compile Include="WebSso\LogoutCommand.cs" />
     <Compile Include="Saml2P\Saml2LogoutRequest.cs" />
+    <Compile Include="UrlExtensions.cs" />
     <Compile Include="XmlHelpers.cs" />
     <Compile Include="Metadata\FilteringXmlDictionaryReader.cs" />
   </ItemGroup>

--- a/Kentor.AuthServices/UrlExtensions.cs
+++ b/Kentor.AuthServices/UrlExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Kentor.AuthServices
+{
+    internal static class UrlExtensions
+    {
+        public static Uri AppendReturnUrl(this Uri url, string returnUrl)
+        {
+            if (url == null || string.IsNullOrWhiteSpace(returnUrl))
+                return url;
+            Uri val;
+            if (!Uri.TryCreate(Uri.UnescapeDataString(returnUrl), UriKind.RelativeOrAbsolute, out val))
+                return url;
+
+            var queryToAppend = "returnUrl=" + val;
+            var baseUri = new UriBuilder(url);
+            if (baseUri.Query.Length > 1)
+                baseUri.Query = baseUri.Query.Substring(1) + "&" + queryToAppend;
+            else
+                baseUri.Query = queryToAppend;
+
+            return baseUri.Uri;
+        }
+    }
+}

--- a/Kentor.AuthServices/WebSSO/AcsCommand.cs
+++ b/Kentor.AuthServices/WebSSO/AcsCommand.cs
@@ -41,7 +41,7 @@ namespace Kentor.AuthServices.WebSso
 
                     var samlResponse = new Saml2Response(unbindResult.Data, request.StoredRequestState?.MessageId);
 
-                    var result = ProcessResponse(options, samlResponse, request.StoredRequestState);
+                    var result = ProcessResponse(options, samlResponse, request.StoredRequestState, unbindResult.RelayState);
                     if(unbindResult.RelayState != null)
                     {
                         result.ClearCookieName = "Kentor." + unbindResult.RelayState;
@@ -88,7 +88,8 @@ namespace Kentor.AuthServices.WebSso
         private static CommandResult ProcessResponse(
             IOptions options,
             Saml2Response samlResponse,
-            StoredRequestState storedRequestState)
+            StoredRequestState storedRequestState, 
+            string relayState)
         {
             var principal = new ClaimsPrincipal(samlResponse.GetClaims(options));
 
@@ -110,7 +111,7 @@ namespace Kentor.AuthServices.WebSso
             return new CommandResult()
             {
                 HttpStatusCode = HttpStatusCode.SeeOther,
-                Location = storedRequestState?.ReturnUrl ?? options.SPOptions.ReturnUrl,
+                Location = storedRequestState?.ReturnUrl ?? options.SPOptions.ReturnUrl.AppendReturnUrl(relayState),
                 Principal = principal,
                 RelayData = storedRequestState?.RelayData,
                 SessionNotOnOrAfter = samlResponse.SessionNotOnOrAfter


### PR DESCRIPTION
In order to fix #250, use request's unbounded `RelayState` as `returnUrl` param on redirect to `SP` 

@AndersAbel this is a fix for `RelayState` feature
