### PR TITLE
Added SkipInResponseToValidation for Saml2Response parsing.

### DIFF
--- a/Kentor.AuthServices/Configuration/Compatibility.cs
+++ b/Kentor.AuthServices/Configuration/Compatibility.cs
@@ -31,6 +31,9 @@ namespace Kentor.AuthServices.Configuration
 
             UnpackEntitiesDescriptorInIdentityProviderMetadata =
                 configElement.UnpackEntitiesDescriptorInIdentityProviderMetadata;
+
+            SkipInResponseToValidation =
+                configElement.SkipInResponseToValidation;
         }
 
         /// <summary>
@@ -39,5 +42,11 @@ namespace Kentor.AuthServices.Configuration
         /// is a single EntityDescriptor and in that case use it.
         /// </summary>
         public bool UnpackEntitiesDescriptorInIdentityProviderMetadata { get; set; }
+
+        /// <summary>
+        /// Some IdP implementations don't set InResponseTo attribute.
+        /// Use this property to skip validation of InReponseTo attribute on the SP side.
+        /// </summary>
+        public bool SkipInResponseToValidation { get; set; }
     }
 }

--- a/Kentor.AuthServices/Configuration/CompatibilityElement.cs
+++ b/Kentor.AuthServices/Configuration/CompatibilityElement.cs
@@ -26,6 +26,8 @@ namespace Kentor.AuthServices.Configuration
 
         const string unpackEntitiesDescriptorInIdentityProviderMetadata
             = nameof(unpackEntitiesDescriptorInIdentityProviderMetadata);
+        const string skipInResponseToValidation
+            = nameof(skipInResponseToValidation);
 
         /// <summary>
         /// If an EntitiesDescriptor element is found when loading metadata
@@ -42,6 +44,23 @@ namespace Kentor.AuthServices.Configuration
             set
             {
                 base[unpackEntitiesDescriptorInIdentityProviderMetadata] = value;
+            }
+        }
+
+        /// <summary>
+        /// Some IdP implementations don't set InResponseTo attribute.
+        /// Use this property to skip validation of InReponseTo attribute on the SP side.
+        /// </summary>
+        [ConfigurationProperty(nameof(skipInResponseToValidation), IsRequired = false)]
+        public bool SkipInResponseToValidation
+        {
+            get
+            {
+                return (bool)base[skipInResponseToValidation];
+            }
+            set
+            {
+                base[skipInResponseToValidation] = value;
             }
         }
     }

--- a/Kentor.AuthServices/WebSSO/AcsCommand.cs
+++ b/Kentor.AuthServices/WebSSO/AcsCommand.cs
@@ -39,7 +39,7 @@ namespace Kentor.AuthServices.WebSso
                     unbindResult = binding.Unbind(request, options);
                     options.Notifications.MessageUnbound(unbindResult);
 
-                    var samlResponse = new Saml2Response(unbindResult.Data, request.StoredRequestState?.MessageId);
+                    var samlResponse = new Saml2Response(unbindResult.Data, request.StoredRequestState?.MessageId, options);
 
                     var result = ProcessResponse(options, samlResponse, request.StoredRequestState);
                     if(unbindResult.RelayState != null)


### PR DESCRIPTION
This is related to https://github.com/KentorIT/authservices/issues/482. I've added new property to Compatibility class and used that property to skip InReponseTo validation in Saml2Response.ReadAndValidateInResponseTo.

I've modified code to propagate options all the way to this method. Please let me know if you recommend some other method.