### PR TITLE
Feature/allow unsigned logout request/ response

### DIFF
--- a/Kentor.AuthServices.Tests/WebSSO/LogoutCommandTests.cs
+++ b/Kentor.AuthServices.Tests/WebSSO/LogoutCommandTests.cs
@@ -292,7 +292,7 @@ namespace Kentor.AuthServices.Tests.WebSSO
         }
 
         [TestMethod]
-        public void LogoutCommand_Run_HandlesLogoutResponseWithoutSignature_SuccessWhenAllowUnsignedLogoutResponse()
+        public void LogoutCommand_Run_HandlesLogoutResponseWithoutSignature_SuccessWhenallowUnsignedLogOffResponse()
         {
             var relayState = "MyRelayState";
             var response = new Saml2LogoutResponse(Saml2StatusCode.Success)
@@ -315,7 +315,7 @@ namespace Kentor.AuthServices.Tests.WebSSO
 
             var options = StubFactory.CreateOptions();
             options.SPOptions.PublicOrigin = new Uri("https://sp.example.com/path/");
-            options.IdentityProviders[0].AllowUnsignedLogOutResponse = true;
+            options.IdentityProviders[0].AllowUnsignedLogOffResponse = true;
 
             CommandResult notifiedCommandResult = null;
             options.Notifications.LogoutCommandResultCreated = cr =>
@@ -462,7 +462,7 @@ namespace Kentor.AuthServices.Tests.WebSSO
         }
 
         [TestMethod]
-        public void LogoutCommand_Run_HandlesLogoutRequestWithoutSignatureThroughRedirectBinding_SuccessWhenAllowUnsignedLogOutRequest()
+        public void LogoutCommand_Run_HandlesLogoutRequestWithoutSignatureThroughRedirectBinding_SuccessWhenAllowUnsignedLogOffRequest()
         {
             var request = new Saml2LogoutRequest()
             {
@@ -480,7 +480,7 @@ namespace Kentor.AuthServices.Tests.WebSSO
 
             var options = StubFactory.CreateOptions();
             options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
-            options.IdentityProviders[0].AllowUnsignedLogOutRequest = true;
+            options.IdentityProviders[0].AllowUnsignedLogOffRequest = true;
 
             CommandResult notifiedCommandResult = null;
             options.Notifications.LogoutCommandResultCreated = cr =>

--- a/Kentor.AuthServices.Tests/WebSSO/LogoutCommandTests.cs
+++ b/Kentor.AuthServices.Tests/WebSSO/LogoutCommandTests.cs
@@ -292,7 +292,7 @@ namespace Kentor.AuthServices.Tests.WebSSO
         }
 
         [TestMethod]
-        public void LogoutCommand_Run_HandlesLogoutResponseWithoutSignature_SuccessWhenallowUnsignedLogOffResponse()
+        public void LogoutCommand_Run_HandlesLogoutResponseWithoutSignature_SuccessWhenAllowUnsignedLogoutResponse()
         {
             var relayState = "MyRelayState";
             var response = new Saml2LogoutResponse(Saml2StatusCode.Success)
@@ -315,7 +315,7 @@ namespace Kentor.AuthServices.Tests.WebSSO
 
             var options = StubFactory.CreateOptions();
             options.SPOptions.PublicOrigin = new Uri("https://sp.example.com/path/");
-            options.IdentityProviders[0].AllowUnsignedLogOffResponse = true;
+            options.IdentityProviders[0].AllowUnsignedLogOutResponse = true;
 
             CommandResult notifiedCommandResult = null;
             options.Notifications.LogoutCommandResultCreated = cr =>
@@ -462,7 +462,7 @@ namespace Kentor.AuthServices.Tests.WebSSO
         }
 
         [TestMethod]
-        public void LogoutCommand_Run_HandlesLogoutRequestWithoutSignatureThroughRedirectBinding_SuccessWhenAllowUnsignedLogOffRequest()
+        public void LogoutCommand_Run_HandlesLogoutRequestWithoutSignatureThroughRedirectBinding_SuccessWhenAllowUnsignedLogOutRequest()
         {
             var request = new Saml2LogoutRequest()
             {
@@ -480,7 +480,7 @@ namespace Kentor.AuthServices.Tests.WebSSO
 
             var options = StubFactory.CreateOptions();
             options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
-            options.IdentityProviders[0].AllowUnsignedLogOffRequest = true;
+            options.IdentityProviders[0].AllowUnsignedLogOutRequest = true;
 
             CommandResult notifiedCommandResult = null;
             options.Notifications.LogoutCommandResultCreated = cr =>

--- a/Kentor.AuthServices/Configuration/IdentityProviderElement.cs
+++ b/Kentor.AuthServices/Configuration/IdentityProviderElement.cs
@@ -125,12 +125,13 @@ namespace Kentor.AuthServices.Configuration
         /// If true log out response without signature is still accepted
         /// If false log out response without signature is not accepted
         /// </summary>
-        [ConfigurationProperty("allowUnsignedLogOffResponse", IsRequired = false, DefaultValue = false)]
-        public bool AllowUnsignedLogOffResponse
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "LogOut")]
+        [ConfigurationProperty("allowUnsignedLogOutResponse", IsRequired = false, DefaultValue = false)]
+        public bool AllowUnsignedLogOutResponse
         {
             get
             {
-                return (bool)base["allowUnsignedLogOffResponse"];
+                return (bool)base["allowUnsignedLogOutResponse"];
             }
         }
 
@@ -139,12 +140,13 @@ namespace Kentor.AuthServices.Configuration
         /// If true log out request without signature is still accepted
         /// If false log out request without signature is not accepted
         /// </summary>
-        [ConfigurationProperty("allowUnsignedLogOffRequest", IsRequired = false, DefaultValue = false)]
-        public bool AllowUnsignedLogOffRequest
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "LogOut")]
+        [ConfigurationProperty("allowUnsignedLogOutRequest", IsRequired = false, DefaultValue = false)]
+        public bool AllowUnsignedLogOutRequest
         {
             get
             {
-                return (bool)base["allowUnsignedLogOffRequest"];
+                return (bool)base["allowUnsignedLogOutRequest"];
             }
         }
 

--- a/Kentor.AuthServices/Configuration/IdentityProviderElement.cs
+++ b/Kentor.AuthServices/Configuration/IdentityProviderElement.cs
@@ -121,6 +121,34 @@ namespace Kentor.AuthServices.Configuration
         }
 
         /// <summary>
+        /// Allow log out response without signature
+        /// If true log out response without signature is still accepted
+        /// If false log out response without signature is not accepted
+        /// </summary>
+        [ConfigurationProperty("allowUnsignedLogOutResponse", IsRequired = false, DefaultValue = false)]
+        public bool AllowUnsignedLogOutResponse
+        {
+            get
+            {
+                return (bool)base["allowUnsignedLogOutResponse"];
+            }
+        }
+
+        /// <summary>
+        /// Allow log out request without signature
+        /// If true log out request without signature is still accepted
+        /// If false log out request without signature is not accepted
+        /// </summary>
+        [ConfigurationProperty("allowUnsignedLogOutRequest", IsRequired = false, DefaultValue = false)]
+        public bool AllowUnsignedLogOutRequest
+        {
+            get
+            {
+                return (bool)base["allowUnsignedLogOutRequest"];
+            }
+        }
+
+        /// <summary>
         /// Enable automatic downloading of metadata form the well-known uri (i.e. interpret
         /// the EntityID as an uri and download metadata from it).
         /// </summary>

--- a/Kentor.AuthServices/Configuration/IdentityProviderElement.cs
+++ b/Kentor.AuthServices/Configuration/IdentityProviderElement.cs
@@ -125,12 +125,12 @@ namespace Kentor.AuthServices.Configuration
         /// If true log out response without signature is still accepted
         /// If false log out response without signature is not accepted
         /// </summary>
-        [ConfigurationProperty("allowUnsignedLogOutResponse", IsRequired = false, DefaultValue = false)]
-        public bool AllowUnsignedLogOutResponse
+        [ConfigurationProperty("allowUnsignedLogOffResponse", IsRequired = false, DefaultValue = false)]
+        public bool AllowUnsignedLogOffResponse
         {
             get
             {
-                return (bool)base["allowUnsignedLogOutResponse"];
+                return (bool)base["allowUnsignedLogOffResponse"];
             }
         }
 
@@ -139,12 +139,12 @@ namespace Kentor.AuthServices.Configuration
         /// If true log out request without signature is still accepted
         /// If false log out request without signature is not accepted
         /// </summary>
-        [ConfigurationProperty("allowUnsignedLogOutRequest", IsRequired = false, DefaultValue = false)]
-        public bool AllowUnsignedLogOutRequest
+        [ConfigurationProperty("allowUnsignedLogOffRequest", IsRequired = false, DefaultValue = false)]
+        public bool AllowUnsignedLogOffRequest
         {
             get
             {
-                return (bool)base["allowUnsignedLogOutRequest"];
+                return (bool)base["allowUnsignedLogOffRequest"];
             }
         }
 

--- a/Kentor.AuthServices/IdentityProvider.cs
+++ b/Kentor.AuthServices/IdentityProvider.cs
@@ -46,8 +46,8 @@ namespace Kentor.AuthServices
             EntityId = new EntityId(config.EntityId);
             binding = config.Binding;
             AllowUnsolicitedAuthnResponse = config.AllowUnsolicitedAuthnResponse;
-            AllowUnsignedLogOutResponse = config.AllowUnsignedLogOutResponse;
-            AllowUnsignedLogOutRequest = config.AllowUnsignedLogOutRequest;
+            AllowUnsignedLogOffResponse = config.AllowUnsignedLogOffResponse;
+            AllowUnsignedLogOffRequest = config.AllowUnsignedLogOffRequest;
 
             metadataLocation = string.IsNullOrEmpty(config.MetadataLocation)
                 ? null : config.MetadataLocation;
@@ -250,12 +250,12 @@ namespace Kentor.AuthServices
         /// <summary>
         /// Is this idp allowed to send unsigned log out responses
         /// </summary>
-        public bool AllowUnsignedLogOutResponse { get; set; }
+        public bool AllowUnsignedLogOffResponse { get; set; }
 
         /// <summary>
         /// Is this idp allowed to send unsigned log out request
         /// </summary>
-        public bool AllowUnsignedLogOutRequest { get; set; }
+        public bool AllowUnsignedLogOffRequest { get; set; }
 
         private string metadataLocation;
 

--- a/Kentor.AuthServices/IdentityProvider.cs
+++ b/Kentor.AuthServices/IdentityProvider.cs
@@ -46,6 +46,9 @@ namespace Kentor.AuthServices
             EntityId = new EntityId(config.EntityId);
             binding = config.Binding;
             AllowUnsolicitedAuthnResponse = config.AllowUnsolicitedAuthnResponse;
+            AllowUnsignedLogOutResponse = config.AllowUnsignedLogOutResponse;
+            AllowUnsignedLogOutRequest = config.AllowUnsignedLogOutRequest;
+
             metadataLocation = string.IsNullOrEmpty(config.MetadataLocation)
                 ? null : config.MetadataLocation;
             WantAuthnRequestsSigned = config.WantAuthnRequestsSigned;
@@ -243,6 +246,16 @@ namespace Kentor.AuthServices
         /// Is this idp allowed to send unsolicited responses, i.e. idp initiated sign in?
         /// </summary>
         public bool AllowUnsolicitedAuthnResponse { get; set; }
+
+        /// <summary>
+        /// Is this idp allowed to send unsigned log out responses
+        /// </summary>
+        public bool AllowUnsignedLogOutResponse { get; set; }
+
+        /// <summary>
+        /// Is this idp allowed to send unsigned log out request
+        /// </summary>
+        public bool AllowUnsignedLogOutRequest { get; set; }
 
         private string metadataLocation;
 

--- a/Kentor.AuthServices/IdentityProvider.cs
+++ b/Kentor.AuthServices/IdentityProvider.cs
@@ -46,8 +46,8 @@ namespace Kentor.AuthServices
             EntityId = new EntityId(config.EntityId);
             binding = config.Binding;
             AllowUnsolicitedAuthnResponse = config.AllowUnsolicitedAuthnResponse;
-            AllowUnsignedLogOffResponse = config.AllowUnsignedLogOffResponse;
-            AllowUnsignedLogOffRequest = config.AllowUnsignedLogOffRequest;
+            AllowUnsignedLogOutResponse = config.AllowUnsignedLogOutResponse;
+            AllowUnsignedLogOutRequest = config.AllowUnsignedLogOutRequest;
 
             metadataLocation = string.IsNullOrEmpty(config.MetadataLocation)
                 ? null : config.MetadataLocation;
@@ -250,12 +250,14 @@ namespace Kentor.AuthServices
         /// <summary>
         /// Is this idp allowed to send unsigned log out responses
         /// </summary>
-        public bool AllowUnsignedLogOffResponse { get; set; }
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "LogOut")]
+        public bool AllowUnsignedLogOutResponse { get; set; }
 
         /// <summary>
         /// Is this idp allowed to send unsigned log out request
         /// </summary>
-        public bool AllowUnsignedLogOffRequest { get; set; }
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "LogOut")]
+        public bool AllowUnsignedLogOutRequest { get; set; }
 
         private string metadataLocation;
 

--- a/Kentor.AuthServices/WebSSO/LogOutCommand.cs
+++ b/Kentor.AuthServices/WebSSO/LogOutCommand.cs
@@ -107,6 +107,12 @@ namespace Kentor.AuthServices.WebSso
                 }
                 var idp = options.IdentityProviders[new EntityId(issuer)];
 
+                if (unbindResult.Data.LocalName == "LogoutRequest" && idp.AllowUnsignedLogOutRequest)
+                    return;
+
+                if (unbindResult.Data.LocalName == "LogoutResponse" && idp.AllowUnsignedLogOutResponse)
+                    return;
+
                 if (!unbindResult.Data.IsSignedByAny(idp.SigningKeys, options.SPOptions.ValidateCertificates))
                 {
                     throw new UnsuccessfulSamlOperationException(string.Format(CultureInfo.InvariantCulture,

--- a/Kentor.AuthServices/WebSSO/LogOutCommand.cs
+++ b/Kentor.AuthServices/WebSSO/LogOutCommand.cs
@@ -107,12 +107,12 @@ namespace Kentor.AuthServices.WebSso
                 }
                 var idp = options.IdentityProviders[new EntityId(issuer)];
 
-                if (unbindResult.Data.LocalName == "LogoutRequest" && idp.AllowUnsignedLogOffRequest)
+                if (unbindResult.Data.LocalName == "LogoutRequest" && idp.AllowUnsignedLogOutRequest)
                 {
                     return;
                 }
 
-                if (unbindResult.Data.LocalName == "LogoutResponse" && idp.AllowUnsignedLogOffResponse)
+                if (unbindResult.Data.LocalName == "LogoutResponse" && idp.AllowUnsignedLogOutResponse)
                 {
                     return;
                 }

--- a/Kentor.AuthServices/WebSSO/LogOutCommand.cs
+++ b/Kentor.AuthServices/WebSSO/LogOutCommand.cs
@@ -108,10 +108,14 @@ namespace Kentor.AuthServices.WebSso
                 var idp = options.IdentityProviders[new EntityId(issuer)];
 
                 if (unbindResult.Data.LocalName == "LogoutRequest" && idp.AllowUnsignedLogOutRequest)
+                {
                     return;
+                }
 
                 if (unbindResult.Data.LocalName == "LogoutResponse" && idp.AllowUnsignedLogOutResponse)
+                {
                     return;
+                }
 
                 if (!unbindResult.Data.IsSignedByAny(idp.SigningKeys, options.SPOptions.ValidateCertificates))
                 {

--- a/Kentor.AuthServices/WebSSO/LogOutCommand.cs
+++ b/Kentor.AuthServices/WebSSO/LogOutCommand.cs
@@ -107,12 +107,12 @@ namespace Kentor.AuthServices.WebSso
                 }
                 var idp = options.IdentityProviders[new EntityId(issuer)];
 
-                if (unbindResult.Data.LocalName == "LogoutRequest" && idp.AllowUnsignedLogOutRequest)
+                if (unbindResult.Data.LocalName == "LogoutRequest" && idp.AllowUnsignedLogOffRequest)
                 {
                     return;
                 }
 
-                if (unbindResult.Data.LocalName == "LogoutResponse" && idp.AllowUnsignedLogOutResponse)
+                if (unbindResult.Data.LocalName == "LogoutResponse" && idp.AllowUnsignedLogOffResponse)
                 {
                     return;
                 }

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -467,6 +467,8 @@ A list of identity providers known to the service provider.
 * [`signOnUrl`](#signonurl-attribute)
 * [`logoutUrl`](#logouturl-attribute)
 * [`allowUnsolicitedAuthnResponse`](#allowunsolicitedauthnresponse-attribute)
+* [`allowUnsignedLogOutRequest`](#allowUnsignedLogOutRequest-attribute)
+* [`allowUnsignedLogOutResponse`](#allowUnsignedLogOutResponse-attribute)
 * [`binding`](#binding-attribute)
 * [`wantAuthnRequestsSigned`](#wantauthnrequestssigned-attribute)
 * [`loadMetadata`](#loadmetadata-attribute)
@@ -508,6 +510,20 @@ process. If `false` InResponseTo is required and the authentication process must
 be initiated by an AuthnRequest from this SP. 
 Note that if the authentication was SP-intiatied, RelayState and InResponseTo
 must be present and valid.
+
+####`allowUnsignedLogOutRequest` Attribute
+*Attribute of the [`<add>`](#add-identityprovider-element) element*
+
+Allow the identity provider to send the saml log out request without the signature.
+If `true` signature in the saml log out request is not required from the IDP.
+If `false` signature in the saml log out request is required from the IDP (Default behavior).
+
+####`allowUnsignedLogOutResponse` Attribute
+*Attribute of the [`<add>`](#add-identityprovider-element) element*
+
+Allow the identity provider to send the saml log out response without the signature.
+If `true` signature in the saml log out response is not required from the IDP.
+If `false` signature in the saml log out response is required from the IDP (Default behavior).
 
 ####`binding` Attribute
 *Optional attribute of the [`<add>`](#add-identityprovider-element) element*

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -467,8 +467,8 @@ A list of identity providers known to the service provider.
 * [`signOnUrl`](#signonurl-attribute)
 * [`logoutUrl`](#logouturl-attribute)
 * [`allowUnsolicitedAuthnResponse`](#allowunsolicitedauthnresponse-attribute)
-* [`allowUnsignedLogOutRequest`](#allowUnsignedLogOutRequest-attribute)
-* [`allowUnsignedLogOutResponse`](#allowUnsignedLogOutResponse-attribute)
+* [`allowUnsignedLogOffRequest`](#allowUnsignedLogOffRequest-attribute)
+* [`allowUnsignedLogOffResponse`](#allowUnsignedLogOffResponse-attribute)
 * [`binding`](#binding-attribute)
 * [`wantAuthnRequestsSigned`](#wantauthnrequestssigned-attribute)
 * [`loadMetadata`](#loadmetadata-attribute)
@@ -511,14 +511,14 @@ be initiated by an AuthnRequest from this SP.
 Note that if the authentication was SP-intiatied, RelayState and InResponseTo
 must be present and valid.
 
-####`allowUnsignedLogOutRequest` Attribute
+####`allowUnsignedLogOffRequest` Attribute
 *Attribute of the [`<add>`](#add-identityprovider-element) element*
 
 Allow the identity provider to send the saml log out request without the signature.
 If `true` signature in the saml log out request is not required from the IDP.
 If `false` signature in the saml log out request is required from the IDP (Default behavior).
 
-####`allowUnsignedLogOutResponse` Attribute
+####`allowUnsignedLogOffResponse` Attribute
 *Attribute of the [`<add>`](#add-identityprovider-element) element*
 
 Allow the identity provider to send the saml log out response without the signature.

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -467,8 +467,8 @@ A list of identity providers known to the service provider.
 * [`signOnUrl`](#signonurl-attribute)
 * [`logoutUrl`](#logouturl-attribute)
 * [`allowUnsolicitedAuthnResponse`](#allowunsolicitedauthnresponse-attribute)
-* [`allowUnsignedLogOffRequest`](#allowUnsignedLogOffRequest-attribute)
-* [`allowUnsignedLogOffResponse`](#allowUnsignedLogOffResponse-attribute)
+* [`allowUnsignedLogOutRequest`](#allowUnsignedLogOutRequest-attribute)
+* [`allowUnsignedLogOutResponse`](#allowUnsignedLogOutResponse-attribute)
 * [`binding`](#binding-attribute)
 * [`wantAuthnRequestsSigned`](#wantauthnrequestssigned-attribute)
 * [`loadMetadata`](#loadmetadata-attribute)
@@ -511,14 +511,14 @@ be initiated by an AuthnRequest from this SP.
 Note that if the authentication was SP-intiatied, RelayState and InResponseTo
 must be present and valid.
 
-####`allowUnsignedLogOffRequest` Attribute
+####`allowUnsignedLogOutRequest` Attribute
 *Attribute of the [`<add>`](#add-identityprovider-element) element*
 
 Allow the identity provider to send the saml log out request without the signature.
 If `true` signature in the saml log out request is not required from the IDP.
 If `false` signature in the saml log out request is required from the IDP (Default behavior).
 
-####`allowUnsignedLogOffResponse` Attribute
+####`allowUnsignedLogOutResponse` Attribute
 *Attribute of the [`<add>`](#add-identityprovider-element) element*
 
 Allow the identity provider to send the saml log out response without the signature.


### PR DESCRIPTION
This is the solution for issue #446.

Background story:
I tried to integrate OneLogin Single Sign On to our application:
(https://support.onelogin.com/hc/en-us/articles/202673944-How-to-Use-the-OneLogin-SAML-Test-Connector)
The issue is when OneLogin sends a saml logout request or response, the saml message doesn't contain the signature and Kentor threw an exception because of that.
This change introduces 2 optional settings to skip validating the log out request/response to work around the fact that some IDP doesn't support signed log out saml message:
allowUnsignedLogOutRequest
allowUnsignedLogOutResponse

Example :

    <identityProviders>
      <add entityId="https://app.onelogin.com/saml/metadata"
           signOnUrl="one login sso log in url"
           logoutUrl="one login sso log out url"
           allowUnsignedLogOutRequest="true" 
           allowUnsignedLogOutResponse="true" 
           binding="HttpRedirect">
            ....
      </add>
    </identityProviders>