### PR TITLE
MetadataLoader - load from stream

### DIFF
--- a/Tests/Tests/Metadata/MetadataLoaderTests.cs
+++ b/Tests/Tests/Metadata/MetadataLoaderTests.cs
@@ -23,7 +23,7 @@ namespace Sustainsys.Saml2.Tests.Metadata
         [TestMethod]
         public void MetadataLoader_LoadIdp_Nullcheck()
         {
-            Action a = () => MetadataLoader.LoadIdp(null);
+            Action a = () => MetadataLoader.LoadIdp((string)null);
 
             a.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("metadataLocation");
         }
@@ -42,7 +42,7 @@ namespace Sustainsys.Saml2.Tests.Metadata
         [TestMethod]
         public void MetadataLoader_LoadFederation_Nullcheck()
         {
-            Action a = () => MetadataLoader.LoadFederation(null);
+            Action a = () => MetadataLoader.LoadFederation((string)null);
 
             a.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("metadataLocation");
         }

--- a/Tests/Tests/Metadata/MetadataLoaderTests.cs
+++ b/Tests/Tests/Metadata/MetadataLoaderTests.cs
@@ -42,7 +42,7 @@ namespace Sustainsys.Saml2.Tests.Metadata
         [TestMethod]
         public void MetadataLoader_LoadFederation_Nullcheck()
         {
-            Action a = () => MetadataLoader.LoadFederation((string)null);
+            Action a = () => MetadataLoader.LoadFederation(null);
 
             a.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("metadataLocation");
         }


### PR DESCRIPTION
Adds overloads to the MetadataLoader to load from a Stream directly for cases where metadata is not stored on the file system and not available online.  This is of particular use in multi-tenant systems where users are able to configure an IdP or SP via a web application.  Additionally, this makes it easier to use a caching layer when dealing with very large metadata files such as the InCommon federation at http://md.incommon.org/InCommon/InCommon-metadata.xml (~43 MB).