### PR TITLE
Use SameSiteMode.None for cookies in ASP.NET Core handler

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/CommandResultExtensions.cs
+++ b/Sustainsys.Saml2.AspNetCore2/CommandResultExtensions.cs
@@ -30,7 +30,13 @@ namespace Sustainsys.Saml2.AspNetCore2
                 httpContext.Response.Cookies.Append(
                     commandResult.SetCookieName,
                     cookieData,
-                    new CookieOptions() { HttpOnly = true } );
+                    new CookieOptions()
+                    {
+                        HttpOnly = true,
+                        // We are expecting a different site to POST back to us,
+                        // so the ASP.Net Core default of Lax is not appropriate in this case
+                        SameSite = SameSiteMode.None
+                    });
             }
 
             if(!string.IsNullOrEmpty(commandResult.ClearCookieName))

--- a/Tests/AspNetCore2.Tests/CommandResultExtensionsTests.cs
+++ b/Tests/AspNetCore2.Tests/CommandResultExtensionsTests.cs
@@ -76,7 +76,7 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
             context.Response.Headers["Location"].SingleOrDefault()
                 .Should().Be("https://destination.com/", "location header should be set");
             context.Response.Cookies.Received().Append(
-                "Saml2.123", expectedCookieData, Arg.Is<CookieOptions>(co => co.HttpOnly));
+                "Saml2.123", expectedCookieData, Arg.Is<CookieOptions>(co => co.HttpOnly && co.SameSite == SameSiteMode.None));
 
             context.Response.Cookies.Received().Delete("Clear-Cookie");
 


### PR DESCRIPTION
Fixes #809 

The default became SameSiteMode.Lax in ASP.NET Core 2, which means that only GET requests from other site will be allowed to send the cookies.