### PR TITLE
ReturnUrl can be null after return from Discovery service

### DIFF
--- a/Kentor.AuthServices/WebSSO/SignInCommand.cs
+++ b/Kentor.AuthServices/WebSSO/SignInCommand.cs
@@ -83,7 +83,7 @@ namespace Kentor.AuthServices.WebSso
 
             if (request.StoredRequestState != null)
             {
-                returnUrl = request.StoredRequestState.ReturnUrl.OriginalString;
+                returnUrl = request.StoredRequestState.ReturnUrl?.OriginalString;
             }
 
             return returnUrl;


### PR DESCRIPTION
Fixes #804 by not assuming that if a StoreRequestState exists then it must also contain a valid ReturnUrl. This will not be true for DS.