### PR TITLE
Make implementations of ICommand public

### DIFF
--- a/Kentor.AuthServices/WebSSO/AcsCommand.cs
+++ b/Kentor.AuthServices/WebSSO/AcsCommand.cs
@@ -15,8 +15,19 @@ using System.Xml;
 
 namespace Kentor.AuthServices.WebSso
 {
-    class AcsCommand : ICommand
+    /// <summary>
+    /// Represents the assertion consumer service command behaviour.
+    /// Instances of this class can be created directly or by using the factory method
+    /// CommandFactory.GetCommand(CommandFactory.AcsCommandName).
+    /// </summary>
+    public class AcsCommand : ICommand
     {
+        /// <summary>
+        /// Run the command, initiating or handling the assertion consumer sequence.
+        /// </summary>
+        /// <param name="request">Request data.</param>
+        /// <param name="options">Options</param>
+        /// <returns>CommandResult</returns>
         public CommandResult Run(HttpRequestData request, IOptions options)
         {
             if(request == null)

--- a/Kentor.AuthServices/WebSSO/LogOutCommand.cs
+++ b/Kentor.AuthServices/WebSSO/LogOutCommand.cs
@@ -14,17 +14,13 @@ using Kentor.AuthServices.Internal;
 namespace Kentor.AuthServices.WebSso
 {
     /// <summary>
-    /// The logout command. Use 
-    /// CommandFactory.Get(CommandFactory.LogoutCommandName) to get an instance.
+    /// Represents the logout command behaviour.
+    /// Instances of this class can be created directly or by using the factory method
+    /// CommandFactory.GetCommand(CommandFactory.LogoutCommandName).
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout")]
     public class LogoutCommand : ICommand
     {
-        /// <summary>
-        /// Ctor, don't want anyone to create instances.
-        /// </summary>
-        internal LogoutCommand() { }
-
         /// <summary>
         /// Run the command, initiating or handling the logout sequence.
         /// </summary>

--- a/Kentor.AuthServices/WebSSO/MetadataCommand.cs
+++ b/Kentor.AuthServices/WebSSO/MetadataCommand.cs
@@ -12,8 +12,19 @@ using Kentor.AuthServices.Metadata;
 
 namespace Kentor.AuthServices.WebSso
 {
-    class MetadataCommand : ICommand
+    /// <summary>
+    /// Represents the service provider metadata command behaviour.
+    /// Instances of this class can be created directly or by using the factory method
+    /// CommandFactory.GetCommand(CommandFactory.MetadataCommandName).
+    /// </summary>
+    public class MetadataCommand : ICommand
     {
+        /// <summary>
+        /// Run the command, creating and returning the service provider metadata.
+        /// </summary>
+        /// <param name="request">Request data.</param>
+        /// <param name="options">Options</param>
+        /// <returns>CommandResult</returns>
         public CommandResult Run(HttpRequestData request, IOptions options)
         {
             if(options == null)

--- a/Kentor.AuthServices/WebSSO/NotFoundCommand.cs
+++ b/Kentor.AuthServices/WebSSO/NotFoundCommand.cs
@@ -7,8 +7,19 @@ using System.Web;
 
 namespace Kentor.AuthServices.WebSso
 {
-    class NotFoundCommand : ICommand
+    /// <summary>
+    /// Represents a missing command.
+    /// Instances of this class are returned by CommandFactory.GetCommand(...)
+    /// when the specified command name is not recognised.
+    /// </summary>
+    public class NotFoundCommand : ICommand
     {
+        /// <summary>
+        /// Run the command, returning a CommandResult specifying an HTTP 404 Not Found status code.
+        /// </summary>
+        /// <param name="request">Request data.</param>
+        /// <param name="options">Options</param>
+        /// <returns>CommandResult</returns>
         public CommandResult Run(HttpRequestData request, IOptions options)
         {
             return new CommandResult()

--- a/Kentor.AuthServices/WebSSO/SignInCommand.cs
+++ b/Kentor.AuthServices/WebSSO/SignInCommand.cs
@@ -10,16 +10,12 @@ using Kentor.AuthServices.Internal;
 namespace Kentor.AuthServices.WebSso
 {
     /// <summary>
-    /// The sign in command. Use 
-    /// CommandFactory.Get(CommandFactory.SignInCommandName) to get an instance.
+    /// Represents the sign in command behaviour.
+    /// Instances of this class can be created directly or by using the factory method
+    /// CommandFactory.GetCommand(CommandFactory.SignInCommandName).
     /// </summary>
     public class SignInCommand : ICommand
     {
-        /// <summary>
-        /// Ctor, don't want anyone to create instances.
-        /// </summary>
-        internal SignInCommand() { }
-
         /// <summary>
         /// Run the command, initiating the sign in sequence.
         /// </summary>


### PR DESCRIPTION
Closes issue #793. 

As discussed in the above issue, these changes allow consumers of the `Kentor.AuthServices` package instantiate the concrete implementations of `ICommand` directly, without needing to resort to the static `CommandFactory.GetCommand(...)` method.

The internal constructors have been removed and XML documentation comments have been added to the concrete classes.