### PR TITLE
Don't re-instantiate Notifications or IdentityProviders in Saml2Options

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/Saml2Options.cs
+++ b/Sustainsys.Saml2.AspNetCore2/Saml2Options.cs
@@ -20,8 +20,6 @@ namespace Sustainsys.Saml2.AspNetCore2
             {
                 ModulePath = "/Saml2"
             };
-            IdentityProviders = new IdentityProviderDictionary();
-            Notifications = new KentorAuthServicesNotifications();
         }
 
         /// <summary>
@@ -39,12 +37,14 @@ namespace Sustainsys.Saml2.AspNetCore2
         /// <summary>
         /// Information about known identity providers.
         /// </summary>
-        public IdentityProviderDictionary IdentityProviders { get; private set; }
+        public IdentityProviderDictionary IdentityProviders { get; }
+            = new IdentityProviderDictionary();
 
         /// <summary>
         /// Set of callbacks that can be used as extension points for various
         /// events.
         /// </summary>
-        public KentorAuthServicesNotifications Notifications { get; private set; }
+        public KentorAuthServicesNotifications Notifications { get; }
+            = new KentorAuthServicesNotifications();
     }
 }

--- a/Sustainsys.Saml2.AspNetCore2/Saml2Options.cs
+++ b/Sustainsys.Saml2.AspNetCore2/Saml2Options.cs
@@ -20,6 +20,8 @@ namespace Sustainsys.Saml2.AspNetCore2
             {
                 ModulePath = "/Saml2"
             };
+            IdentityProviders = new IdentityProviderDictionary();
+            Notifications = new KentorAuthServicesNotifications();
         }
 
         /// <summary>
@@ -37,14 +39,12 @@ namespace Sustainsys.Saml2.AspNetCore2
         /// <summary>
         /// Information about known identity providers.
         /// </summary>
-        public IdentityProviderDictionary IdentityProviders { get; }
-            = new IdentityProviderDictionary();
+        public IdentityProviderDictionary IdentityProviders { get; private set; }
 
         /// <summary>
         /// Set of callbacks that can be used as extension points for various
         /// events.
         /// </summary>
-        public KentorAuthServicesNotifications Notifications =>
-            new KentorAuthServicesNotifications();
+        public KentorAuthServicesNotifications Notifications { get; private set; }
     }
 }


### PR DESCRIPTION
The properties for accessing Notifications and IdentityProviders were read only and always returned new instances.  They are now created once during construction, like the SPOptions.

This should resolve [#883](https://github.com/Sustainsys/Saml2/issues/833) and get Notification registration working.