### PR TITLE
Fix broken links to web.config samples

### DIFF
--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -3,8 +3,8 @@ kentor.AuthServices Configuration
 To use Kentor.AuthServices in an application and configure it in web.config
 (which is the default for the httpmodule and mvc libraries) it must be enabled 
 in the application's `web.config`. The sample applications contains complete
-working [`web.config`](../SampleApplication/Web.config) examples. For 
-ASP.NET MVC applications see [`this working web.config`](../SampleMvcApplication/Web.config)
+working [`web.config`](../Samples/SampleApplication/Web.config) examples. For 
+ASP.NET MVC applications see [`this working web.config`](../Samples/SampleMvcApplication/Web.config)
 example. Applications using the owin library usually make their configuration
 in code and in that case no web.config changes are needed. If an owin library
 is set up to use web.config (by passing `true` to the `KentorAuthServicesAuthenticationOptions` 


### PR DESCRIPTION
I just noticed these links were broken, so I modified them to point to what I assume are the correct files.