### PR TITLE
Fixed issue #853

### DIFF
--- a/Kentor.AuthServices/SAML2P/Saml2AuthenticationRequest.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2AuthenticationRequest.cs
@@ -47,7 +47,7 @@ namespace Kentor.AuthServices.Saml2P
             {
                 x.AddAttributeIfNotNullOrEmpty("ProtocolBinding", Saml2Binding.Saml2BindingTypeToUri(Binding.Value));
             }
-            x.AddAttributeIfNotNullOrEmpty("AssertionConsumerServiceURL", AssertionConsumerServiceUrl);
+            x.AddAttributeIfNotNullOrEmpty("AssertionConsumerServiceURL", AssertionConsumerServiceUrl?.OriginalString);
             x.AddAttributeIfNotNullOrEmpty("AttributeConsumingServiceIndex", AttributeConsumingServiceIndex);
             if (ForceAuthentication)
             {


### PR DESCRIPTION
Fixed encoding bug -> used Uri.OriginalString instead of Uri.ToString() This ensures that the whole url is properly encoded for example http:// is encoded with ToString as http:%2F%2F and if you use OriginalString as http%3A%2F%2F.