### PR TITLE
Add new identity provider configuration to allow unsigned log out request/response

### DIFF
--- a/Sustainsys.Saml2/Configuration/IdentityProviderElement.cs
+++ b/Sustainsys.Saml2/Configuration/IdentityProviderElement.cs
@@ -137,6 +137,36 @@ namespace Sustainsys.Saml2.Configuration
         }
 
         /// <summary>
+        /// Allow log out response without signature
+        /// If true log out response without signature is still accepted
+        /// If false log out response without signature is not accepted
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "LogOut")]
+        [ConfigurationProperty("allowUnsignedLogOutResponse", IsRequired = false, DefaultValue = false)]
+        public bool AllowUnsignedLogOutResponse
+        {
+            get
+            {
+                return (bool)base["allowUnsignedLogOutResponse"];
+            }
+        }
+
+        /// <summary>
+        /// Allow log out request without signature
+        /// If true log out request without signature is still accepted
+        /// If false log out request without signature is not accepted
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "LogOut")]
+        [ConfigurationProperty("allowUnsignedLogOutRequest", IsRequired = false, DefaultValue = false)]
+        public bool AllowUnsignedLogOutRequest
+        {
+            get
+            {
+                return (bool)base["allowUnsignedLogOutRequest"];
+            }
+        }
+
+        /// <summary>
         /// Enable automatic downloading of metadata form the well-known uri (i.e. interpret
         /// the EntityID as an uri and download metadata from it).
         /// </summary>

--- a/Sustainsys.Saml2/IdentityProvider.cs
+++ b/Sustainsys.Saml2/IdentityProvider.cs
@@ -53,6 +53,9 @@ namespace Sustainsys.Saml2
             EntityId = new EntityId(config.EntityId);
             binding = config.Binding;
             AllowUnsolicitedAuthnResponse = config.AllowUnsolicitedAuthnResponse;
+            AllowUnsignedLogOutResponse = config.AllowUnsignedLogOutResponse;
+            AllowUnsignedLogOutRequest = config.AllowUnsignedLogOutRequest;
+
             metadataLocation = string.IsNullOrEmpty(config.MetadataLocation)
                 ? null : config.MetadataLocation;
             WantAuthnRequestsSigned = config.WantAuthnRequestsSigned;
@@ -255,6 +258,18 @@ namespace Sustainsys.Saml2
         /// Is this idp allowed to send unsolicited responses, i.e. idp initiated sign in?
         /// </summary>
         public bool AllowUnsolicitedAuthnResponse { get; set; }
+
+        /// <summary>
+        /// Is this idp allowed to send unsigned log out responses
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "LogOut")]
+        public bool AllowUnsignedLogOutResponse { get; set; }
+
+        /// <summary>
+        /// Is this idp allowed to send unsigned log out request
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "LogOut")]
+        public bool AllowUnsignedLogOutRequest { get; set; }
 
         private string metadataLocation;
 

--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -117,6 +117,16 @@ namespace Sustainsys.Saml2.WebSso
                 }
                 var idp = options.IdentityProviders[new EntityId(issuer)];
 
+                if (unbindResult.Data.LocalName == "LogoutRequest" && idp.AllowUnsignedLogOutRequest)
+                {
+                    return;
+                }
+
+                if (unbindResult.Data.LocalName == "LogoutResponse" && idp.AllowUnsignedLogOutResponse)
+                {
+                    return;
+                }
+
                 if (!unbindResult.Data.IsSignedByAny(
                     idp.SigningKeys,
                     options.SPOptions.ValidateCertificates,

--- a/Tests/Tests/WebSSO/LogoutCommandTests.cs
+++ b/Tests/Tests/WebSSO/LogoutCommandTests.cs
@@ -365,6 +365,53 @@ namespace Sustainsys.Saml2.Tests.WebSSO
         }
 
         [TestMethod]
+        public void LogoutCommand_Run_HandlesLogoutResponseWithoutSignature_SuccessWhenAllowUnsignedLogoutResponse()
+        {
+            var relayState = "MyRelayState";
+            var response = new Saml2LogoutResponse(Saml2StatusCode.Success)
+            {
+                DestinationUrl = new Uri("http://sp.example.com/path/AuthServices/logout"),
+                Issuer = new EntityId("https://idp.example.com"),
+                InResponseTo = new Saml2Id(),
+                SigningCertificate = null,
+                RelayState = relayState
+            };
+
+            var bindResult = Saml2Binding.Get(Saml2BindingType.HttpRedirect)
+                .Bind(response);
+
+            var request = new HttpRequestData("GET",
+                bindResult.Location,
+                "http://sp-internal.example.com/path/AuthServices",
+                null,
+                new StoredRequestState(null, new Uri("http://loggedout.example.com"), null, null));
+
+            var options = StubFactory.CreateOptions();
+            options.SPOptions.PublicOrigin = new Uri("https://sp.example.com/path/");
+            options.IdentityProviders[0].AllowUnsignedLogOutResponse = true;
+
+            CommandResult notifiedCommandResult = null;
+            options.Notifications.LogoutCommandResultCreated = cr =>
+            {
+                notifiedCommandResult = cr;
+            };
+
+            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+                .Run(request, options);
+
+            actual.Should().BeSameAs(notifiedCommandResult);
+
+            var expected = new CommandResult
+            {
+                Location = new Uri("http://loggedout.example.com"),
+                HttpStatusCode = HttpStatusCode.SeeOther,
+                ClearCookieName = "Kentor." + relayState
+            };
+
+            actual.ShouldBeEquivalentTo(expected);
+        }
+
+        [TestMethod]
         public void LogoutCommand_Run_HandlesLogoutResponse_InPost()
         {
             var relayState = "TestState";
@@ -438,6 +485,83 @@ namespace Sustainsys.Saml2.Tests.WebSSO
                 notifiedCommandResult = cr;
             };
             
+            // We're using unbind to verify the created message and UnBind
+            // expects the issuer to be a known Idp for signature validation.
+            // Add a dummy with the right issuer name and key.
+            var dummyIdp = new IdentityProvider(options.SPOptions.EntityId, options.SPOptions);
+            dummyIdp.SigningKeys.AddConfiguredKey(SignedXmlHelper.TestCert);
+            options.IdentityProviders.Add(dummyIdp);
+
+            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+                .Run(httpRequest, options);
+
+            var expected = new CommandResult()
+            {
+                HttpStatusCode = HttpStatusCode.SeeOther,
+                TerminateLocalSession = true
+                // Deliberately not comparing Location
+            };
+
+            HttpUtility.ParseQueryString(actual.Location.Query)["Signature"]
+                .Should().NotBeNull("LogoutResponse should be signed");
+
+            actual.ShouldBeEquivalentTo(expected, opt => opt.Excluding(cr => cr.Location));
+            actual.Should().BeSameAs(notifiedCommandResult);
+
+            var actualUnbindResult = Saml2Binding.Get(Saml2BindingType.HttpRedirect)
+                .Unbind(new HttpRequestData("GET", actual.Location), options);
+
+            var actualMessage = actualUnbindResult.Data;
+
+            var expectedMessage = XmlHelpers.XmlDocumentFromString(
+                $@"<samlp:LogoutResponse xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol""
+                    xmlns=""urn:oasis:names:tc:SAML:2.0:assertion""
+                    Destination=""https://idp.example.com/logout""
+                    Version=""2.0"">
+                    <Issuer>{options.SPOptions.EntityId.Id}</Issuer>
+                    <samlp:Status>
+                        <samlp:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success""/>
+                    </samlp:Status>
+                </samlp:LogoutResponse>").DocumentElement;
+
+            // Set generated attributes to actual values.
+            expectedMessage.SetAttribute("ID", actualMessage.GetAttribute("ID"));
+            expectedMessage.SetAttribute("IssueInstant", actualMessage.GetAttribute("IssueInstant"));
+            expectedMessage.SetAttribute("InResponseTo", request.Id.Value);
+
+            actualMessage.Should().BeEquivalentTo(expectedMessage);
+
+            actualUnbindResult.RelayState.Should().Be(request.RelayState);
+            actualUnbindResult.TrustLevel.Should().Be(TrustLevel.Signature);
+        }
+
+        [TestMethod]
+        public void LogoutCommand_Run_HandlesLogoutRequestWithoutSignatureThroughRedirectBinding_SuccessWhenAllowUnsignedLogOutRequest()
+        {
+            var request = new Saml2LogoutRequest()
+            {
+                DestinationUrl = new Uri("http://sp.example.com/path/AuthServices/logout"),
+                Issuer = new EntityId("https://idp.example.com"),
+                SigningCertificate = null,
+                NameId = new Saml2NameIdentifier("NameId"),
+                SessionIndex = "SessionID",
+            };
+
+            var bindResult = Saml2Binding.Get(Saml2BindingType.HttpRedirect)
+                .Bind(request);
+
+            var httpRequest = new HttpRequestData("GET", bindResult.Location);
+
+            var options = StubFactory.CreateOptions();
+            options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
+            options.IdentityProviders[0].AllowUnsignedLogOutRequest = true;
+
+            CommandResult notifiedCommandResult = null;
+            options.Notifications.LogoutCommandResultCreated = cr =>
+            {
+                notifiedCommandResult = cr;
+            };
+
             // We're using unbind to verify the created message and UnBind
             // expects the issuer to be a known Idp for signature validation.
             // Add a dummy with the right issuer name and key.

--- a/Tests/Tests/WebSSO/LogoutCommandTests.cs
+++ b/Tests/Tests/WebSSO/LogoutCommandTests.cs
@@ -405,7 +405,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             {
                 Location = new Uri("http://loggedout.example.com"),
                 HttpStatusCode = HttpStatusCode.SeeOther,
-                ClearCookieName = "Kentor." + relayState
+                ClearCookieName = "Saml2." + relayState
             };
 
             actual.ShouldBeEquivalentTo(expected);

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -506,6 +506,8 @@ A list of identity providers known to the service provider.
 * [`signOnUrl`](#signonurl-attribute)
 * [`logoutUrl`](#logouturl-attribute)
 * [`allowUnsolicitedAuthnResponse`](#allowunsolicitedauthnresponse-attribute)
+* [`allowUnsignedLogOutRequest`](#allowUnsignedLogOutRequest-attribute)
+* [`allowUnsignedLogOutResponse`](#allowUnsignedLogOutResponse-attribute)
 * [`binding`](#binding-attribute)
 * [`wantAuthnRequestsSigned`](#wantauthnrequestssigned-attribute)
 * [`loadMetadata`](#loadmetadata-attribute)
@@ -548,6 +550,20 @@ process. If `false` InResponseTo is required and the authentication process must
 be initiated by an AuthnRequest from this SP. 
 Note that if the authentication was SP-intiatied, RelayState and InResponseTo
 must be present and valid.
+
+####`allowUnsignedLogOutRequest` Attribute
+*Attribute of the [`<add>`](#add-identityprovider-element) element*
+
+Allow the identity provider to send the saml log out request without the signature.
+If `true` signature in the saml log out request is not required from the IDP.
+If `false` signature in the saml log out request is required from the IDP (Default behavior).
+
+####`allowUnsignedLogOutResponse` Attribute
+*Attribute of the [`<add>`](#add-identityprovider-element) element*
+
+Allow the identity provider to send the saml log out response without the signature.
+If `true` signature in the saml log out response is not required from the IDP.
+If `false` signature in the saml log out response is required from the IDP (Default behavior).
 
 #### `binding` Attribute
 *Optional attribute of the [`<add>`](#add-identityprovider-element) element*


### PR DESCRIPTION
Code from @MinhNguyenDev PR: https://github.com/Sustainsys/Saml2/pull/590 which is based on an old version of Saml2 (and had conflicts with master).

This is the solution for issue #446, adding two new parameters to the IdentityProvider-element in config:
allowUnsignedLogOutRequest and allowUnsignedLogOutResponse. For use when the IDP does not support signing of log out request/response.

```

<identityProviders>
  <add entityId="https://app.onelogin.com/saml/metadata"
       signOnUrl="one login sso log in url"
       logoutUrl="one login sso log out url"
       allowUnsignedLogOutRequest="true" 
       allowUnsignedLogOutResponse="true" 
       binding="HttpRedirect">
        ....
  </add>
</identityProviders>
```