### PR TITLE
Added XmlCreated event to allow for change of raw XML data

### DIFF
--- a/Sustainsys.Saml2/SAML2P/Saml2ArtifactResolve.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2ArtifactResolve.cs
@@ -37,11 +37,14 @@ namespace Sustainsys.Saml2.Saml2P
         /// <returns>string containing the Xml data.</returns>
         public override string ToXml()
         {
-            return new XElement(
+            var xElement = new XElement(
                 Saml2Namespaces.Saml2P + "ArtifactResolve",
                 base.ToXNodes(),
-                new XElement(Saml2Namespaces.Saml2P + "Artifact", Artifact))
-                .ToString();
+                new XElement(Saml2Namespaces.Saml2P + "Artifact", Artifact));
+
+            OnXmlCreated(xElement);
+
+            return xElement.ToString();
         }
     }
 }

--- a/Sustainsys.Saml2/SAML2P/Saml2AuthenticationRequest.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2AuthenticationRequest.cs
@@ -69,6 +69,8 @@ namespace Sustainsys.Saml2.Saml2P
 
             AddScoping(x);
 
+            OnXmlCreated(x);
+
             return x;
         }
 

--- a/Sustainsys.Saml2/SAML2P/Saml2LogoutRequest.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2LogoutRequest.cs
@@ -103,6 +103,8 @@ namespace Sustainsys.Saml2.Saml2P
             x.Add(new XElement(Saml2Namespaces.Saml2P + "SessionIndex",
                 SessionIndex));
 
+            OnXmlCreated(x);
+
             return x.ToString();
         }
     }

--- a/Sustainsys.Saml2/SAML2P/Saml2RequestBase.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2RequestBase.cs
@@ -138,6 +138,15 @@ namespace Sustainsys.Saml2.Saml2P
             }
         }
 
+        /// <summary>
+        /// Fire the XmlCreated event
+        /// </summary>
+        /// <param name="xElement"></param>
+        protected void OnXmlCreated(XElement xElement)
+        {
+            XmlCreated(this, xElement);
+        }
+
         private void ValidateCorrectDocument(XmlElement xml)
         {
             if (xml.LocalName != LocalName
@@ -151,6 +160,11 @@ namespace Sustainsys.Saml2.Saml2P
                 throw new XmlException("Wrong or unsupported SAML2 version");
             }
         }
+
+        /// <summary>
+        /// Event that fires just before ToXml returns. Allows manipulation of the raw XML
+        /// </summary>
+        public event EventHandler<XElement> XmlCreated = delegate { };
 
         /// <summary>
         /// Serializes the message into wellformed Xml.
@@ -168,6 +182,7 @@ namespace Sustainsys.Saml2.Saml2P
         /// to the signature processing rules of each binding.
         /// </summary>
         public X509Certificate2 SigningCertificate { get; set; }
+
         /// <summary>
         /// The signing algorithm to use when signing the message during binding, 
         /// according to the signature processing rules of each binding.

--- a/Tests/Tests/Saml2P/Saml2ArtifactResolveTests.cs
+++ b/Tests/Tests/Saml2P/Saml2ArtifactResolveTests.cs
@@ -43,5 +43,19 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             actual.ShouldBeEquivalentTo(expected, opt => opt.IgnoringCyclicReferences());
         }
+
+        [TestMethod]
+        public void Saml2ArtifactResolve_ToXml_ToXml_PreservesCustomChanges()
+        {
+            var subject = new Saml2ArtifactResolve();
+            subject.XmlCreated += (s, e) =>
+            {
+                e.Add(new XAttribute("CustomAttribute", "CustomValue"));
+            };
+
+            var xml = subject.ToXml();
+
+            xml.Should().Contain("CustomAttribute=\"CustomValue\"");
+        }
     }
 }

--- a/Tests/Tests/Saml2P/Saml2AuthenticationRequestTests.cs
+++ b/Tests/Tests/Saml2P/Saml2AuthenticationRequestTests.cs
@@ -407,6 +407,20 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             subject.Should().BeNull();
         }
 
+        [TestMethod]
+        public void Saml2AuthenticationRequest_ToXml_PreservesCustomChanges()
+        {
+            var subject = new Saml2AuthenticationRequest();
+            subject.XmlCreated += (s, e) =>
+            {
+                e.Add(new XAttribute("CustomAttribute", "CustomValue"));
+            };
+
+            var xml = subject.ToXml();
+
+            xml.Should().Contain("CustomAttribute=\"CustomValue\"");
+        }
+
         private void Saml2AuthenticationRequest_ToXElement_AddsRequestedAuthnContextUtil(AuthnContextComparisonType comparisonType, string expectedComparisonType)
         {
             var classRef = "http://www.Sustainsys.se";

--- a/Tests/Tests/Saml2P/Saml2LogoutRequestTests.cs
+++ b/Tests/Tests/Saml2P/Saml2LogoutRequestTests.cs
@@ -59,6 +59,32 @@ xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
         }
 
         [TestMethod]
+        public void Saml2LogoutRequest_ToXml_PreservesCustomChanges()
+        {
+            var subject = new Saml2LogoutRequest()
+            {
+                DestinationUrl = new Uri("http://idp.example.com/logout"),
+                Issuer = new EntityId("http://sp.example.com/"),
+                NameId = new Saml2NameIdentifier("005a06e0-ad82-110d-a556-004005b13a2b")
+                {
+                    Format = new Uri(NameIdFormat.Persistent.GetUri().AbsoluteUri),
+                    NameQualifier = "qualifier",
+                    SPNameQualifier = "spQualifier",
+                    SPProvidedId = "spId"
+                },
+                SessionIndex = "SessionId"
+            };
+            subject.XmlCreated += (s, e) =>
+            {
+                e.Add(new XAttribute("CustomAttribute", "CustomValue"));
+            };
+
+            var xml = subject.ToXml();
+
+            xml.Should().Contain("CustomAttribute=\"CustomValue\"");
+        }
+
+        [TestMethod]
         public void Saml2LogoutRequest_FromXml()
         {
             var xmlData =
@@ -118,5 +144,7 @@ xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
             a.ShouldThrow<ArgumentNullException>()
                 .And.ParamName.Should().Be("xml");
         }
+
+
     }
 }


### PR DESCRIPTION
Add XmlCreated event to Saml2RequestBase that fires during the execution of ToXml. This allows the user to manipulate the raw XML before it is send to the IDP.