### PR TITLE
Handle OneTimeUse SAML2Reponse

### DIFF
--- a/Sustainsys.Saml2/Configuration/Compatibility.cs
+++ b/Sustainsys.Saml2/Configuration/Compatibility.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sustainsys.Saml2.Configuration
 {
@@ -33,6 +29,7 @@ namespace Sustainsys.Saml2.Configuration
                 configElement.UnpackEntitiesDescriptorInIdentityProviderMetadata;
             DisableLogoutStateCookie = configElement.DisableLogoutStateCookie;
             IgnoreMissingInResponseTo = configElement.IgnoreMissingInResponseTo;
+            AcceptOneTimeUseAssertions = configElement.AcceptOneTimeUseAssertions;
         }
 
         /// <summary>
@@ -71,5 +68,12 @@ namespace Sustainsys.Saml2.Configuration
         /// IgnoreMissingInResponseTo to true will always skip the check.
         /// </summary>
         public bool IgnoreMissingInResponseTo { get; set; }
+
+        /// <summary>
+        /// If a received SamlResponse is for one time use (Assertion/Conditions/OneTimeUse)
+        /// this will allow it to be used for WebSSO.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "OneTime")]
+        public bool AcceptOneTimeUseAssertions { get; set; }
     }
 }

--- a/Sustainsys.Saml2/Configuration/CompatibilityElement.cs
+++ b/Sustainsys.Saml2/Configuration/CompatibilityElement.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Configuration;
 
 namespace Sustainsys.Saml2.Configuration
 {
@@ -83,6 +78,26 @@ namespace Sustainsys.Saml2.Configuration
             set
             {
                 base[ignoreMissingInResponseTo] = value;
+            }
+        }
+
+        const string acceptOneTimeUseAssertions = nameof(acceptOneTimeUseAssertions);
+
+        /// <summary>
+        /// If a received SamlResponse is for one time use (Assertion/Conditions/OneTimeUse)
+        /// this will allow it to be used for WebSSO.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "OneTime")]
+        [ConfigurationProperty(acceptOneTimeUseAssertions, IsRequired = false, DefaultValue = false)]
+        public bool AcceptOneTimeUseAssertions
+        {
+            get
+            {
+                return (bool)base[acceptOneTimeUseAssertions];
+            }
+            set
+            {
+                base[acceptOneTimeUseAssertions] = value;
             }
         }
     }

--- a/Sustainsys.Saml2/SAML2P/Saml2Response.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2Response.cs
@@ -563,6 +563,12 @@ namespace Sustainsys.Saml2.Saml2P
 
                     handler.DetectReplayedToken(token);
 
+                    // Have checked for replayed token, don't need to validate OneTimeUse (Saml2SecurityTokenHandler doesn't support it either)
+                    if (token.Assertion.Conditions != null)
+                    {
+                        token.Assertion.Conditions.OneTimeUse = false;
+                    }
+
                     var validateAudience = options.SPOptions
                         .Saml2PSecurityTokenHandler
                         .SamlSecurityTokenRequirement

--- a/Sustainsys.Saml2/SAML2P/Saml2Response.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2Response.cs
@@ -564,10 +564,8 @@ namespace Sustainsys.Saml2.Saml2P
                     handler.DetectReplayedToken(token);
 
                     // Have checked for replayed token, don't need to validate OneTimeUse (Saml2SecurityTokenHandler doesn't support it either)
-                    if (token.Assertion.Conditions != null)
-                    {
-                        token.Assertion.Conditions.OneTimeUse = false;
-                    }
+                    // a TechNet article that discusses this related to AD-FS http://social.technet.microsoft.com/wiki/contents/articles/2994.ad-fs-2-0-id4149-the-saml2securitytoken-is-rejected-because-the-saml2-assertion-specifies-a-onetimeuse-condition.aspx
+                    token.Assertion.Conditions.OneTimeUse = false;
 
                     var validateAudience = options.SPOptions
                         .Saml2PSecurityTokenHandler

--- a/Sustainsys.Saml2/SAML2P/Saml2Response.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2Response.cs
@@ -563,10 +563,11 @@ namespace Sustainsys.Saml2.Saml2P
 
                     handler.DetectReplayedToken(token);
 
-                    // Have checked for replayed token, don't need to validate OneTimeUse (Saml2SecurityTokenHandler doesn't support it either)
-                    // a TechNet article that discusses this related to AD-FS http://social.technet.microsoft.com/wiki/contents/articles/2994.ad-fs-2-0-id4149-the-saml2securitytoken-is-rejected-because-the-saml2-assertion-specifies-a-onetimeuse-condition.aspx
-                    token.Assertion.Conditions.OneTimeUse = false;
-
+                    if (token.Assertion.Conditions.OneTimeUse == true && options.SPOptions.Compatibility.AcceptOneTimeUseAssertions)
+                    {
+                        token.Assertion.Conditions.OneTimeUse = false;
+                    }
+                 
                     var validateAudience = options.SPOptions
                         .Saml2PSecurityTokenHandler
                         .SamlSecurityTokenRequirement
@@ -579,8 +580,8 @@ namespace Sustainsys.Saml2.Saml2P
                     options.SPOptions.Logger.WriteVerbose("Validated conditions for SAML2 Response " + Id);
 
                     sessionNotOnOrAfter = DateTimeHelper.EarliestTime(sessionNotOnOrAfter,
-                    token.Assertion.Statements.OfType<Saml2AuthenticationStatement>()
-                        .SingleOrDefault()?.SessionNotOnOrAfter);
+                                                                      token.Assertion.Statements.OfType<Saml2AuthenticationStatement>()
+                                                                        .SingleOrDefault()?.SessionNotOnOrAfter);
 
                     yield return handler.CreateClaims(token);
                 }

--- a/Tests/AspNetCore2.Tests/AspNetCore2.Tests.csproj
+++ b/Tests/AspNetCore2.Tests/AspNetCore2.Tests.csproj
@@ -46,7 +46,7 @@
       <HintPath>..\..\packages\FluentAssertions.4.5.0\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Authentication">
-      <HintPath>..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.aspnetcore.authentication\2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Authentication.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Authentication.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Authentication.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.Abstractions.dll</HintPath>
@@ -60,8 +60,8 @@
     <Reference Include="Microsoft.AspNetCore.Http.Features, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Features.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection">
-      <HintPath>..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.extensions.dependencyinjection\2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
@@ -111,7 +111,9 @@
     <Compile Include="TestHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Sustainsys.Saml2\Sustainsys.Saml2.csproj">

--- a/Tests/AspNetCore2.Tests/Saml2HandlerTests.cs
+++ b/Tests/AspNetCore2.Tests/Saml2HandlerTests.cs
@@ -294,17 +294,6 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
         }
 
         [TestMethod]
-        public void Saml2Handler_ChallengeAsync_NullchecksProperties()
-        {
-            var context = new Saml2HandlerTestContext();
-
-            Func<Task> f = async () => await context.Subject.ChallengeAsync(null);
-
-            f.ShouldThrow<ArgumentNullException>()
-                .And.ParamName.Should().Be("properties");
-        }
-
-        [TestMethod]
         public void Saml2Handler_Ctor_NullcheckDataProtectorProvider()
         {
             Action a = () => new Saml2Handler(null, null, null);

--- a/Tests/AspNetCore2.Tests/packages.config
+++ b/Tests/AspNetCore2.Tests/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.AspNetCore.DataProtection.Abstractions" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.AspNetCore.Http.Features" version="2.0.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.0.0" targetFramework="net47" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.Options" version="2.0.0" targetFramework="net461" />

--- a/Tests/Tests/Configuration/SPOptionsTests.cs
+++ b/Tests/Tests/Configuration/SPOptionsTests.cs
@@ -88,6 +88,7 @@ namespace Sustainsys.Saml2.Tests.Configuration
             subject.Compatibility.UnpackEntitiesDescriptorInIdentityProviderMetadata.Should().BeTrue();
             subject.Compatibility.DisableLogoutStateCookie.Should().BeTrue();
             subject.Compatibility.IgnoreMissingInResponseTo.Should().BeTrue();
+            subject.Compatibility.AcceptOneTimeUseAssertions.Should().BeFalse();
         }
 
         [TestMethod]

--- a/Tests/Tests/Configuration/SPOptionsTests.cs
+++ b/Tests/Tests/Configuration/SPOptionsTests.cs
@@ -26,6 +26,7 @@ namespace Sustainsys.Saml2.Tests.Configuration
                 SustainsysSaml2Section.Current.Compatibility.UnpackEntitiesDescriptorInIdentityProviderMetadata = false;
                 SustainsysSaml2Section.Current.Compatibility.DisableLogoutStateCookie = false;
                 SustainsysSaml2Section.Current.Compatibility.IgnoreMissingInResponseTo = false;
+                SustainsysSaml2Section.Current.Compatibility.AcceptOneTimeUseAssertions = false;
                 SustainsysSaml2Section.Current.Compatibility.AllowChange = false;
             }
         }
@@ -67,6 +68,7 @@ namespace Sustainsys.Saml2.Tests.Configuration
             config.Compatibility.UnpackEntitiesDescriptorInIdentityProviderMetadata = true;
             config.Compatibility.DisableLogoutStateCookie = true;
             config.Compatibility.IgnoreMissingInResponseTo = true;
+            config.Compatibility.AcceptOneTimeUseAssertions = true;
 
             SPOptions subject = new SPOptions(SustainsysSaml2Section.Current);
             subject.ReturnUrl.Should().Be(config.ReturnUrl);
@@ -89,6 +91,7 @@ namespace Sustainsys.Saml2.Tests.Configuration
             subject.Compatibility.DisableLogoutStateCookie.Should().BeTrue();
             subject.Compatibility.IgnoreMissingInResponseTo.Should().BeTrue();
             subject.Compatibility.AcceptOneTimeUseAssertions.Should().BeFalse();
+            subject.Compatibility.AcceptOneTimeUseAssertions.Should().BeTrue();
         }
 
         [TestMethod]

--- a/Tests/Tests/Configuration/SPOptionsTests.cs
+++ b/Tests/Tests/Configuration/SPOptionsTests.cs
@@ -90,7 +90,6 @@ namespace Sustainsys.Saml2.Tests.Configuration
             subject.Compatibility.UnpackEntitiesDescriptorInIdentityProviderMetadata.Should().BeTrue();
             subject.Compatibility.DisableLogoutStateCookie.Should().BeTrue();
             subject.Compatibility.IgnoreMissingInResponseTo.Should().BeTrue();
-            subject.Compatibility.AcceptOneTimeUseAssertions.Should().BeFalse();
             subject.Compatibility.AcceptOneTimeUseAssertions.Should().BeTrue();
         }
 

--- a/Tests/Tests/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests/Saml2P/Saml2ResponseTests.cs
@@ -2258,6 +2258,40 @@ namespace Sustainsys.Saml2.Tests.Saml2P
         }
 
         [TestMethod]
+        public void Saml2Response_OneTimeUse_FailsWhenNotAllowed()
+        {
+            var response =
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                <saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + @"_Assertion1""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"">
+                      <saml2:OneTimeUse />
+                    </saml2:Conditions>                
+                </saml2:Assertion>
+            </saml2p:Response>";
+
+            var signedResponse = SignedXmlHelper.SignXml(response);
+
+            Options options = Options.FromConfiguration;
+
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options);
+            a.ShouldThrow<SecurityTokenValidationException>();
+        }
+
+        [TestMethod]
         public void Saml2Response_OneTimeUse_FailsOnRetry()
         {
             var response =

--- a/Tests/Tests/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests/Saml2P/Saml2ResponseTests.cs
@@ -2286,6 +2286,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var signedResponse = SignedXmlHelper.SignXml(response);
 
             Options options = Options.FromConfiguration;
+            options.SPOptions.Compatibility.AcceptOneTimeUseAssertions = false;
 
             Action a = () => Saml2Response.Read(signedResponse).GetClaims(options);
             a.ShouldThrow<SecurityTokenValidationException>();

--- a/Tests/Tests/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests/Saml2P/Saml2ResponseTests.cs
@@ -2250,7 +2250,10 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var signedResponse = SignedXmlHelper.SignXml(response);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            Options options = Options.FromConfiguration;
+            options.SPOptions.Compatibility.AcceptOneTimeUseAssertions = true;
+
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options);
             a.ShouldNotThrow();
         }
 
@@ -2282,10 +2285,13 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var signedResponse = SignedXmlHelper.SignXml(response);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            Options options = Options.FromConfiguration;
+            options.SPOptions.Compatibility.AcceptOneTimeUseAssertions = true;
+
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options);
             a.ShouldNotThrow();
 
-            a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            a = () => Saml2Response.Read(signedResponse).GetClaims(options);
             a.ShouldThrow<SecurityTokenReplayDetectedException>();
         }
 

--- a/Tests/Tests/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests/Saml2P/Saml2ResponseTests.cs
@@ -2221,5 +2221,129 @@ namespace Sustainsys.Saml2.Tests.Saml2P
                 .ShouldThrow<InvalidOperationException>()
                 .WithMessage("*GetClaims*");
         }
+
+        [TestMethod]
+        public void Saml2Response_OneTimeUse_IsAllowed()
+        {
+            var response =
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                <saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + @"_Assertion1""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"">
+                      <saml2:OneTimeUse />
+                    </saml2:Conditions>                
+                </saml2:Assertion>
+            </saml2p:Response>";
+
+            var signedResponse = SignedXmlHelper.SignXml(response);
+
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            a.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void Saml2Response_OneTimeUse_FailsOnRetry()
+        {
+            var response =
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                <saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + @"_Assertion1""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"">
+                      <saml2:OneTimeUse />
+                    </saml2:Conditions>                
+                </saml2:Assertion>
+            </saml2p:Response>";
+
+            var signedResponse = SignedXmlHelper.SignXml(response);
+
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            a.ShouldNotThrow();
+
+            a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            a.ShouldThrow<SecurityTokenReplayDetectedException>();
+        }
+
+        [TestMethod]
+        public void Saml2Response_GetClaims_ThrowsOnMissingConditions()
+        {
+            var response =
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                <saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + @"_Assertion1""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                </saml2:Assertion>
+            </saml2p:Response>";
+
+            Action a = () => Saml2Response.Read(SignedXmlHelper.SignXml(response)).GetClaims(Options.FromConfiguration);
+            a.ShouldThrow<InvalidOperationException>();
+        }
+
+        [TestMethod]
+        public void Saml2Response_GetClaims_ThrowsOnMissingConditionsWithCustomTokenReplayCacheExpiration()
+        {
+            var response =
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                <saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + @"_Assertion1""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                </saml2:Assertion>
+            </saml2p:Response>";
+
+            Options options = Options.FromConfiguration;
+            options.SPOptions.Saml2PSecurityTokenHandler.Configuration.TokenReplayCacheExpirationPeriod = new TimeSpan(0, 5, 0);
+
+            Action a = () => Saml2Response.Read(SignedXmlHelper.SignXml(response)).GetClaims(options);
+            a.ShouldThrow<SecurityTokenValidationException>();
+        }
     }
 }

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -779,6 +779,7 @@ providers.
 
 #### Attributes
 * [`unpackEntitiesDescriptorInIdentityProviderMetadata`](#unpackentitiesdescriptorinidentityprovidermetadata-attribute)
+* [`acceptOneTimeUseAssertions`](#acceptonetimeuseassertions-attribute)
 
 #### `unpackEntitiesDescriptorInIdentityProviderMetadata` Attribute
 * Optional attribute of [`unpackEntitiesDescriptorInIdentityProviderMetadata`](#unpackentitiesdescriptorinidentityprovidermetadata-attribute)*
@@ -786,6 +787,12 @@ providers.
 If an EntitiesDescriptor element is found when loading metadata for an
 IdentityProvider, automatically check inside it if there is a single
 EntityDescriptor and in that case use it.
+
+####`unpackEntitiesDescriptorInIdentityProviderMetadata` Attribute
+* Optional attribute of [`acceptOneTimeUseAssertions`](#acceptonetimeuseassertions-attribute)*
+
+If a received SamlResponse is for one time use (Assertion/Conditions/OneTimeUse)
+this will allow it to be used for WebSSO.
 
 #### `IgnoreAuthenticationContextInResponse` Attribute
 


### PR DESCRIPTION
I have rebased the branch from this PR https://github.com/Sustainsys/Saml2/pull/524 onto master.

Any possibility to get this merged?


(I also deleted Saml2Handler_ChallengeAsync_NullchecksProperties test since it failed, and the ChallengeAsync does no longer throw exception on null property after this commit: https://github.com/Sustainsys/Saml2/commit/71c96d4b2de318d1372047c38bb8ff09c86fa26d.)