### PR TITLE
Change of license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,21 @@
-GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+MIT License
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+Copyright (c) 2018 Sustainsys AB and contributors
 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-  0. Additional Definitions.
-
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
-
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,8 @@
+*******************************************************************************
+* THIS LICENSE APPLIES TO VERSIONS 2.0.0 AND ABOVE ONLY. FOR PREVIOUS         *
+* VERSIONS PLEASE SEE https://github.com/Sustainsys/Saml2/blob/v1.0.0/LICENSE *
+*******************************************************************************
+
 MIT License
 
 Copyright (c) 2018 Sustainsys AB and contributors


### PR DESCRIPTION
When I initially created this project 5 years ago, I choose the LGPL license to ensure that any adoptions of the library were contributed back to the community. Little did I foresee how big this project would grow - both in number of features and users.

During the years, the choice of license has been questioned several times and so far nobody has shown me a case where LGPL would disallow them from what they want.

However, I have finally been convinced that LGPL is causing so much questioning and actually prohibits big organizations that are willing to sponsor work with the library from doing so. So I'm finally moving to MIT.

This is the PR to change the license. For the license change to be valid, previous contributors need to agree - or their contributions must be rewritten. I will be using this post to keep track of agreements. If you are a contributor that want to agree, please just vote with a thumbs up to this post to mark your acceptance. If you do not agree, please vote with a thumbs down and if possible send me a mail at anders@sustainsys.com to discuss why.

## Contributors
Contributors are listed in the order they appear in the contributors list. Some contributors have approved through e-mail, they are marked as checked, even though they do not have a thumbs up vote here.
- [x] @AndersAbel
- [x] @albinsunnanbo 
- [x] @explunit 
- [x] @blushingpenguin 
- [x] @jimmytoenners 
- [x] @Raschmann 
- [x] @rasmuskl 
- [x] @wagich
- [x] @roswah 
- [x] @Bidou44 
- [x] @dahlsailrunner 
- [x] @TobbeHolmstrom 
- [x] @jpsullivan 
- [x] @plequang 
- [x] <del>@dufourpy </del> No response received, code replaced
- [x] @tgardner 
- [x] @ASupinski 
- [x] <del>@henningjensen </del> No response received, code removed/replaced.
- [x] @xxjthxx 
- [x] <del>@mip1983 </del> Code was related to System.IdentityModel implementation and is removed as part of move to Microsoft.IdentityModel packages.
- [x] @doormalena 
- [x] @wjr- 
- [x] @arieltrevisan 
- [x] @gheeres 
- [x] @lisabylund 
- [x] @robvanuden 
- [x] @jobrolin 
- [x] <del>@SWSSolutions </del> Code replaced.
- [x] @federicobarera 
- [x] @robertpmansion 
- [x] <del>@ronaldscott </del> Configuration docs, already removed due to move to read-the-docs.
- [x] <del>@leonmeijer  </del> Removal of duplicate package references in StubIdp, nothing left from this as it as a removal.
- [x] @Peperud 
- [x] <del>@dariusdamalakas </del> Code has been removed.
- [x] @ksgopal4 
- [x] @atschirren 
- [x] @brockallen 
- [x] @dammejed 
- [x] <del>@redapplewithleaves </del> Typo fix to documentation that has now been removed due to move to read-the-docs.
- [x] <del>@neugenes </del> Fix to documentation that has now been removed due to move to read-the-docs.
- [x] @duncansmart 
- [x] @TalalTayyab 
- [x] @trejjam