### PR TITLE
add support for idp selection

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/Saml2Handler.cs
+++ b/Sustainsys.Saml2.AspNetCore2/Saml2Handler.cs
@@ -67,10 +67,10 @@ namespace Sustainsys.Saml2.AspNetCore2
 
         private string CurrentUri
         {
-            get => context.Request.Scheme + "://" 
-                + context.Request.Host 
-                + context.Request.PathBase 
-                + context.Request.Path 
+            get => context.Request.Scheme + "://"
+                + context.Request.Host
+                + context.Request.PathBase
+                + context.Request.Path
                 + context.Request.QueryString;
         }
 
@@ -85,8 +85,16 @@ namespace Sustainsys.Saml2.AspNetCore2
 
             var requestData = context.ToHttpRequestData(null);
 
+
+            Metadata.EntityId entityId = null;
+
+            if (properties.Items.TryGetValue("idp", out var entityIdString))
+            {
+                entityId = new Metadata.EntityId(entityIdString);
+            }
+
             var result = SignInCommand.Run(
-                null,
+                entityId,
                 redirectUri,
                 requestData,
                 options,
@@ -105,7 +113,7 @@ namespace Sustainsys.Saml2.AspNetCore2
         /// <InheritDoc />
         public async Task<bool> HandleRequestAsync()
         {
-            if(context.Request.Path.StartsWithSegments(options.SPOptions.ModulePath, StringComparison.Ordinal))
+            if (context.Request.Path.StartsWithSegments(options.SPOptions.ModulePath, StringComparison.Ordinal))
             {
                 var commandName = context.Request.Path.Value.Substring(
                     options.SPOptions.ModulePath.Length).TrimStart('/');

--- a/Tests/AspNetCore2.Tests/Saml2HandlerTests.cs
+++ b/Tests/AspNetCore2.Tests/Saml2HandlerTests.cs
@@ -66,12 +66,21 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
                             opt.SPOptions)
                         {
                             SingleSignOnServiceUrl = new Uri("https://idp.example.com/sso"),
+                            Binding = Saml2BindingType.HttpRedirect,
+                        };
+
+                        var secondIdp = new IdentityProvider(
+                            new EntityId("https://idp2.example.com"),
+                            opt.SPOptions)
+                        {
+                            SingleSignOnServiceUrl = new Uri("https://idp2.example.com/sso"),
                             Binding = Saml2BindingType.HttpRedirect
                         };
 
                         idp.SigningKeys.AddConfiguredKey(SignedXmlHelper.TestCert);
-
+                        
                         opt.IdentityProviders.Add(idp);
+                        opt.IdentityProviders.Add(secondIdp);
 
                     }), 1),
                     Enumerable.Repeat<IPostConfigureOptions<Saml2Options>>(
@@ -101,6 +110,41 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
             response.StatusCode.Should().Be(303);
             response.Headers["Location"].Single()
                 .Should().StartWith("https://idp.example.com/sso?SAMLRequest=");
+
+            var state = new StoredRequestState(StubDataProtector.Unprotect(
+                HttpRequestData.GetBinaryData(cookieData)));
+
+            state.ReturnUrl.OriginalString.Should().Be("https://sp.example.com/LoggedIn");
+
+            // Don't dual-store the return-url.
+            state.RelayData.Values.Should().NotContain("https://sp.example.com/LoggedIn");
+        }
+
+        [TestMethod]
+        public async Task Saml2Handler_ChallengeAsync_RedirectsToSelectedIdp()
+        {
+            var context = new Saml2HandlerTestContext();
+
+            var authProps = new AuthenticationProperties()
+            {
+                RedirectUri = "https://sp.example.com/LoggedIn"
+            };
+
+            authProps.Items["idp"] = "https://idp2.example.com";
+
+            var response = context.HttpContext.Response;
+
+            string cookieData = null;
+            response.Cookies.Append(
+                Arg.Any<string>(),
+                Arg.Do<string>(v => cookieData = v),
+                Arg.Any<CookieOptions>());
+
+            await context.Subject.ChallengeAsync(authProps);
+
+            response.StatusCode.Should().Be(303);
+            response.Headers["Location"].Single()
+                .Should().StartWith("https://idp2.example.com/sso?SAMLRequest=");
 
             var state = new StoredRequestState(StubDataProtector.Unprotect(
                 HttpRequestData.GetBinaryData(cookieData)));


### PR DESCRIPTION
Add a way to select Idp to be used in a similar fashion as https://github.com/Sustainsys/Saml2/blob/master/docs/owin-middleware.rst#selecting-idp

```csharp
var properties = _signInManager.ConfigureExternalAuthenticationProperties(samlScheme, redirectUrl);
properties.Items.Add("idp", method.GetConfiguration<Saml2IdpConfiguration>().EntityId);
return new ChallengeResult(samlScheme, properties);
```