### PR TITLE
More tests for Duo's SAML vulnerabilities

### DIFF
--- a/Sustainsys.Saml2/XmlHelpers.cs
+++ b/Sustainsys.Saml2/XmlHelpers.cs
@@ -175,7 +175,31 @@ namespace Sustainsys.Saml2
                 throw new ArgumentNullException(nameof(xmlDocument));
             }
 
-            xmlDocument.DocumentElement.Sign(cert, includeKeyInfo, signingAlgorithm);
+            xmlDocument.DocumentElement.Sign(cert, includeKeyInfo, signingAlgorithm, SignedXml.XmlDsigExcC14NTransformUrl);
+        }
+
+        /// <summary>
+        /// Sign an xml document with the supplied cert.
+        /// </summary>
+        /// <param name="xmlDocument">XmlDocument to be signed. The signature is
+        /// added as a node in the document, right after the Issuer node.</param>
+        /// <param name="cert">Certificate to use when signing.</param>
+        /// <param name="includeKeyInfo">Include public key in signed output.</param>
+        /// <param name="signingAlgorithm">Uri of signing algorithm to use.</param>
+        /// <param name="canonicalizationMethod">The canonicalization to use.</param>
+        public static void Sign(
+            this XmlDocument xmlDocument,
+            X509Certificate2 cert,
+            bool includeKeyInfo,
+            string signingAlgorithm,
+            string canonicalizationMethod)
+        {
+            if (xmlDocument == null)
+            {
+                throw new ArgumentNullException(nameof(xmlDocument));
+            }
+
+            xmlDocument.DocumentElement.Sign(cert, includeKeyInfo, signingAlgorithm, canonicalizationMethod);
         }
 
         /// <summary>
@@ -208,6 +232,29 @@ namespace Sustainsys.Saml2
             {
                 throw new ArgumentNullException(nameof(xmlElement));
             }
+            xmlElement.Sign(cert, includeKeyInfo, signingAlgorithm, SignedXml.XmlDsigExcC14NTransformUrl);
+        }
+
+        /// <summary>
+        /// Sign an xml element with the supplied cert.
+        /// </summary>
+        /// <param name="xmlElement">xmlElement to be signed. The signature is
+        /// added as a node in the document, right after the Issuer node.</param>
+        /// <param name="cert">Certificate to use when signing.</param>
+        /// <param name="includeKeyInfo">Include public key in signed output.</param>
+        /// <param name="signingAlgorithm">The signing algorithm to use.</param>
+        /// <param name="canonicalizationMethod">The canonicalization to use.</param>
+        public static void Sign(
+            this XmlElement xmlElement,
+            X509Certificate2 cert,
+            bool includeKeyInfo,
+            string signingAlgorithm,
+            string canonicalizationMethod)
+        {
+            if (xmlElement == null)
+            {
+                throw new ArgumentNullException(nameof(xmlElement));
+            }
 
             if (cert == null)
             {
@@ -225,7 +272,7 @@ namespace Sustainsys.Saml2
 			signedXml.SigningKey = EnvironmentHelpers.IsNetCore ? cert.PrivateKey :
 				((RSACryptoServiceProvider)cert.PrivateKey)
 				.GetSha256EnabledRSACryptoServiceProvider();
-            signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
+            signedXml.SignedInfo.CanonicalizationMethod = canonicalizationMethod;
             signedXml.SignedInfo.SignatureMethod = signingAlgorithm;
 
 			// We need a document unique ID on the element to sign it -- make one up if it's missing

--- a/Tests/TestHelpers/SignedXmlHelper.cs
+++ b/Tests/TestHelpers/SignedXmlHelper.cs
@@ -45,7 +45,8 @@ namespace Sustainsys.Saml2.TestHelpers
             string xml,
             bool includeKeyInfo = false,
             bool preserveWhitespace = true,
-            string signingAlgorithmName = null)
+            string signingAlgorithmName = null,
+            string canonicalizationMethod = null)
         {
             var xmlDoc = XmlHelpers.CreateSafeXmlDocument();
             xmlDoc.PreserveWhitespace = preserveWhitespace;
@@ -57,7 +58,7 @@ namespace Sustainsys.Saml2.TestHelpers
             }
             else
             {
-                xmlDoc.Sign(TestCert, includeKeyInfo, signingAlgorithmName);
+                xmlDoc.Sign(TestCert, includeKeyInfo, signingAlgorithmName, canonicalizationMethod);
             }
 
             return xmlDoc.OuterXml;

--- a/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
@@ -335,7 +335,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
                 IssueInstant=""2013-09-25T00:00:00Z"">
                     <saml2:Issuer>https://idp.example.com</saml2:Issuer>
                     <saml2:Subject>
-                        <saml2:NameID>Some<!--Comment-->User</saml2:NameID>
+                        <saml2:NameID>SomeUser</saml2:NameID>
                         <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
                     </saml2:Subject>
                     <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"" />
@@ -343,7 +343,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             </saml2p:Response>";
 
             var signedResponse = SignedXmlHelper.SignXml(response, false, true, XmlHelpers.GetDefaultSigningAlgorithmName(), SignedXml.XmlDsigC14NWithCommentsTransformUrl);
-            var modifiedSignedResponse = signedResponse.Replace("Some<!--Comment-->User", "Some<!--Comment2-->User");
+            var modifiedSignedResponse = signedResponse.Replace("SomeUser", "Some<!--Comment-->User");
 
             Action a = () => Saml2Response.Read(modifiedSignedResponse).GetClaims(StubFactory.CreateOptions());
             a.Should().Throw<InvalidSignatureException>()

--- a/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
@@ -287,6 +287,69 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             claims.Single().FindFirst("CommentTest").Value.Should().Be("SomeValue");
         }
 
+        [TestMethod]
+        public void Saml2Response_GetClaims_ModifiedSignedAttribute_WithoutCommentsCanonicalization()
+        {
+            var response =
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                <saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + @"_Assertion1""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>Some<!--Comment-->User</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"" />
+                </saml2:Assertion>
+            </saml2p:Response>";
+
+            var signedResponse = SignedXmlHelper.SignXml(response, false, true, XmlHelpers.GetDefaultSigningAlgorithmName(), SignedXml.XmlDsigC14NWithCommentsTransformUrl);
+            var modifiedSignedResponse = signedResponse.Replace("Some<!--Comment-->User", "Some<!--Comment2-->User");
+
+            var claims = Saml2Response.Read(modifiedSignedResponse).GetClaims(StubFactory.CreateOptions());
+            claims.Single().FindFirst(ClaimTypes.NameIdentifier).Value.Should().Be("SomeUser");
+        }
+
+        [TestMethod]
+        public void Saml2Response_GetClaims_ModifiedSignedAttribute_WithCommentsCanonicalization()
+        {
+            var response =
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                <saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + @"_Assertion1""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>Some<!--Comment-->User</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"" />
+                </saml2:Assertion>
+            </saml2p:Response>";
+
+            var signedResponse = SignedXmlHelper.SignXml(response, false, true, XmlHelpers.GetDefaultSigningAlgorithmName(), SignedXml.XmlDsigC14NWithCommentsTransformUrl);
+            var modifiedSignedResponse = signedResponse.Replace("Some<!--Comment-->User", "Some<!--Comment2-->User");
+
+            Action a = () => Saml2Response.Read(modifiedSignedResponse).GetClaims(StubFactory.CreateOptions());
+            a.Should().Throw<InvalidSignatureException>()
+                .WithMessage("Signature didn't verify. Have the contents been tampered with?");
+
+        }
 
         [TestMethod]
         public void Saml2Response_GetClaims_CorrectSignedResponseMessageSecondaryKey()


### PR DESCRIPTION
As a follow-up to #921 I thought it would be useful to add two additional tests to those already added in https://github.com/Sustainsys/Saml2/commit/782ac71fef58a7595a0dead745e29431f4a6fc7b This PR is not ready to merge yet but wanted some initial discussion:
 1. Adding a comment to SAML response **after** the signature has been applied, but using the default canonicalization
 1. Adding a comment to SAML response after the signature has been applied, using the `#WithComments` canonicalization variant as suggested in the [Duo article](https://duo.com/blog/duo-finds-saml-vulnerabilities-affecting-multiple-implementations).

Unfortunately this second one does not fail signature validation as I expected. Is the Duo article incorrect or am I doing something wrong in the test?
