### PR TITLE
Introduce the Strategy pattern to IdentityProviderDictionary

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/Saml2Options.cs
+++ b/Sustainsys.Saml2.AspNetCore2/Saml2Options.cs
@@ -44,7 +44,7 @@ namespace Sustainsys.Saml2.AspNetCore2
         /// <summary>
         /// Information about known identity providers.
         /// </summary>
-        public IdentityProviderDictionary IdentityProviders { get; }
+        public IIdentityProviderDictionary IdentityProviders { get; set; }
             = new IdentityProviderDictionary();
 
         /// <summary>

--- a/Sustainsys.Saml2.Owin/Saml2AuthenticationOptions.cs
+++ b/Sustainsys.Saml2.Owin/Saml2AuthenticationOptions.cs
@@ -48,16 +48,20 @@ namespace Sustainsys.Saml2.Owin
         /// </summary>
         public SPOptions SPOptions { get; set; }
 
-        private readonly IdentityProviderDictionary identityProviders = new IdentityProviderDictionary();
+        private IIdentityProviderDictionary identityProviders = new IdentityProviderDictionary();
 
         /// <summary>
         /// Available identity providers.
         /// </summary>
-        public IdentityProviderDictionary IdentityProviders
+        public IIdentityProviderDictionary IdentityProviders
         {
             get
             {
                 return identityProviders;
+            }
+            set
+            {
+                identityProviders = value;
             }
         }
 

--- a/Sustainsys.Saml2/Configuration/IIdentityProviderDictionary.cs
+++ b/Sustainsys.Saml2/Configuration/IIdentityProviderDictionary.cs
@@ -1,0 +1,81 @@
+﻿using Sustainsys.Saml2.Metadata;
+using System.Collections.Generic;
+
+namespace Sustainsys.Saml2.Configuration
+{
+    /// <summary>
+    /// The interface for identity provider dictionary
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix", Justification = "It works like dictionary, even though it doesn't implement the full interface.")]
+    public interface IIdentityProviderDictionary
+    {
+        /// <summary>
+        /// Gets an idp from the entity id.
+        /// </summary>
+        /// <param name="entityId">entity Id to look up.</param>
+        /// <returns>IdentityProvider</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1043:UseIntegralOrStringArgumentForIndexers")]
+        IdentityProvider this[EntityId entityId]
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Add an identity provider to the collection..
+        /// </summary>
+        /// <param name="idp">Identity provider to add.</param>
+        void Add(IdentityProvider idp);
+
+        /// <summary>
+        /// The default identity provider; i.e. the first registered of the currently known.
+        /// </summary>
+        IdentityProvider Default
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets all currently known identity providers. Note that the returned
+        /// enumeration is a copy to avoid race conditions.
+        /// </summary>
+        IEnumerable<IdentityProvider> KnownIdentityProviders
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Try to get the value of an idp with a given entity id.
+        /// </summary>
+        /// <param name="idpEntityId">Entity id to search for.</param>
+        /// <param name="idp">The idp, if found.</param>
+        /// <returns>True if an idp with the given entity id was found.</returns>
+        bool TryGetValue(EntityId idpEntityId, out IdentityProvider idp);
+
+        /// <summary>
+        /// Checks if there are no known identity providers.
+        /// </summary>
+        bool IsEmpty
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Removes the idp with the given entity id, if present. If no such
+        /// entity is found, nothing is done.
+        /// </summary>
+        /// <param name="idp">EntityId of idp to remove.</param>
+        void Remove(EntityId idp);
+
+
+        /// <summary>
+        // Used by tests.
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        IdentityProvider this[int index]
+        {
+            get;
+        }
+    }
+}

--- a/Sustainsys.Saml2/Configuration/IOptions.cs
+++ b/Sustainsys.Saml2/Configuration/IOptions.cs
@@ -22,7 +22,7 @@ namespace Sustainsys.Saml2.Configuration
         /// <summary>
         /// Information about known identity providers.
         /// </summary>
-        IdentityProviderDictionary IdentityProviders { get; }
+        IIdentityProviderDictionary IdentityProviders { get; set; }
 
         /// <summary>
         /// Set of callbacks that can be used as extension points for various

--- a/Sustainsys.Saml2/Configuration/IdentityProviderDictionary.cs
+++ b/Sustainsys.Saml2/Configuration/IdentityProviderDictionary.cs
@@ -19,7 +19,7 @@ namespace Sustainsys.Saml2.Configuration
     /// this part of the code shouldn't be that performance sensitive.
     /// </remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix", Justification="It works like dictionary, even though it doesn't implement the full interface.")]
-    public class IdentityProviderDictionary
+    public class IdentityProviderDictionary : IIdentityProviderDictionary
     {
         private Dictionary<EntityId, IdentityProvider> dictionary =
             new Dictionary<EntityId, IdentityProvider>(EntityIdEqualityComparer.Instance);
@@ -106,7 +106,7 @@ namespace Sustainsys.Saml2.Configuration
         }
 
         // Used by tests.
-        internal IdentityProvider this[int i]
+        public IdentityProvider this[int i]
         {
             get
             {

--- a/Sustainsys.Saml2/Configuration/Options.cs
+++ b/Sustainsys.Saml2/Configuration/Options.cs
@@ -62,16 +62,20 @@ namespace Sustainsys.Saml2.Configuration
         /// </summary>
         public SPOptions SPOptions { get; }
 
-        private readonly IdentityProviderDictionary identityProviders = new IdentityProviderDictionary();
+        private IIdentityProviderDictionary identityProviders = new IdentityProviderDictionary();
 
         /// <summary>
         /// Available identity providers.
         /// </summary>
-        public IdentityProviderDictionary IdentityProviders
+        public IIdentityProviderDictionary IdentityProviders
         {
             get
             {
                 return identityProviders;
+            }
+            set
+            {
+                identityProviders = value;
             }
         }
     }


### PR DESCRIPTION
Introduce the Strategy pattern to IdentityproviderDictionary in order to allow clients of this package to bring their own implementations. This provides a solution to issue #1042.