### PR TITLE
Add support to use the RelayState as the return url.

### DIFF
--- a/Sustainsys.Saml2/Configuration/IdentityProviderElement.cs
+++ b/Sustainsys.Saml2/Configuration/IdentityProviderElement.cs
@@ -220,19 +220,19 @@ namespace Sustainsys.Saml2.Configuration
         }
 
         /// <summary>
-        /// Indicates that the IDP sends the redirect url as part of the RelayState.
+        /// Indicates that the IDP sends the return url as part of the RelayState.
         /// This is used when <see cref="AllowUnsolicitedAuthnResponse"/> is enabled.
         /// </summary>
-        [ConfigurationProperty("relayStateUsedAsRedirectUrl", IsRequired = false, DefaultValue = false)]
-        public bool RelayStateUsedAsRedirectUrl
+        [ConfigurationProperty("relayStateUsedAsReturnUrl", IsRequired = false, DefaultValue = false)]
+        public bool RelayStateUsedAsReturnUrl
         {
             get
             {
-                return (bool)base["relayStateUsedAsRedirectUrl"];
+                return (bool)base["relayStateUsedAsReturnUrl"];
             }
             set
             {
-                base["relayStateUsedAsRedirectUrl"] = value;
+                base["relayStateUsedAsReturnUrl"] = value;
             }
         }
     }

--- a/Sustainsys.Saml2/Configuration/IdentityProviderElement.cs
+++ b/Sustainsys.Saml2/Configuration/IdentityProviderElement.cs
@@ -218,5 +218,22 @@ namespace Sustainsys.Saml2.Configuration
                 base[disableOutboundLogoutRequests] = value;
             }
         }
+
+        /// <summary>
+        /// Indicates that the IDP sends the redirect url as part of the RelayState.
+        /// This is used when <see cref="AllowUnsolicitedAuthnResponse"/> is enabled.
+        /// </summary>
+        [ConfigurationProperty("relayStateUsedAsRedirectUrl", IsRequired = false, DefaultValue = false)]
+        public bool RelayStateUsedAsRedirectUrl
+        {
+            get
+            {
+                return (bool)base["relayStateUsedAsRedirectUrl"];
+            }
+            set
+            {
+                base["relayStateUsedAsRedirectUrl"] = value;
+            }
+        }
     }
 }

--- a/Sustainsys.Saml2/IdentityProvider.cs
+++ b/Sustainsys.Saml2/IdentityProvider.cs
@@ -83,7 +83,7 @@ namespace Sustainsys.Saml2
                 Validate();
             }
 
-            RelayStateUsedAsReturnUrl = config.RelayStateUsedAsRedirectUrl;
+            RelayStateUsedAsReturnUrl = config.RelayStateUsedAsReturnUrl;
         }
 
         private void Validate()
@@ -257,7 +257,7 @@ namespace Sustainsys.Saml2
         public bool AllowUnsolicitedAuthnResponse { get; set; }
 
         /// <summary>
-        /// Does the RelayState contains the redirect url?, 
+        /// Does the RelayState contains the return url?, 
         /// This setting is used only when the AllowUnsolicitedAuthnResponse setting is enabled.
         /// </summary>
         public bool RelayStateUsedAsReturnUrl { get; set; }

--- a/Sustainsys.Saml2/IdentityProvider.cs
+++ b/Sustainsys.Saml2/IdentityProvider.cs
@@ -82,6 +82,8 @@ namespace Sustainsys.Saml2
             {
                 Validate();
             }
+
+            RelayStateUsedAsReturnUrl = config.RelayStateUsedAsRedirectUrl;
         }
 
         private void Validate()
@@ -253,6 +255,12 @@ namespace Sustainsys.Saml2
         /// Is this idp allowed to send unsolicited responses, i.e. idp initiated sign in?
         /// </summary>
         public bool AllowUnsolicitedAuthnResponse { get; set; }
+
+        /// <summary>
+        /// Does the RelayState contains the redirect url?, 
+        /// This setting is used only when the AllowUnsolicitedAuthnResponse setting is enabled.
+        /// </summary>
+        public bool RelayStateUsedAsReturnUrl { get; set; }
 
         private string metadataLocation;
 

--- a/Sustainsys.Saml2/WebSSO/AcsCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/AcsCommand.cs
@@ -174,6 +174,6 @@ in the configuration.";
         internal const string RelayStateMissing =
 @"Relay state data missing from the response.
 the application is expecting a return url as part of the RelayState response from the IDP.
-This is expected because the setting 'relayStateUsedAsRedirectUrl' has been set to true.";
+This is expected because the setting 'relayStateUsedAsReturnUrl' has been set to true.";
     }
 }

--- a/Sustainsys.Saml2/WebSSO/AcsCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/AcsCommand.cs
@@ -1,5 +1,6 @@
 ﻿using Sustainsys.Saml2.Configuration;
 using Sustainsys.Saml2.Exceptions;
+using Sustainsys.Saml2.Internal;
 using Sustainsys.Saml2.Metadata;
 using Sustainsys.Saml2.Saml2P;
 using System;
@@ -117,10 +118,14 @@ namespace Sustainsys.Saml2.WebSso
 
                 if (identityProvider.RelayStateUsedAsReturnUrl)
                 {
-                    if (Uri.IsWellFormedUriString(relayState, UriKind.Absolute))
+                    if (!PathHelper.IsLocalWebUrl(relayState))
                     {
-                        return new Uri(relayState);
+                        if (!options.Notifications.ValidateAbsoluteReturnUrl(relayState))
+                        {
+                            throw new InvalidOperationException("Return Url must be a relative Url.");
+                        }
                     }
+                    return new Uri(relayState, UriKind.RelativeOrAbsolute);
                 }
             }
 

--- a/Tests/Tests.NETCore/App.config
+++ b/Tests/Tests.NETCore/App.config
@@ -34,7 +34,7 @@
       <add entityId="https://idp4.example.com" signOnUrl="https://idp4.example.com/idp" allowUnsolicitedAuthnResponse="false" binding="HttpPost" outboundSigningAlgorithm="sha256" wantAuthnRequestsSigned="true">
         <signingCertificate fileName="Sustainsys.Saml2.Tests.pfx"/>
       </add>
-      <add entityId="https://idp5.example.com" signOnUrl="https://idp5.example.com/idp" allowUnsolicitedAuthnResponse="true" binding="HttpPost" relayStateUsedAsRedirectUrl="true">
+      <add entityId="https://idp5.example.com" signOnUrl="https://idp5.example.com/idp" allowUnsolicitedAuthnResponse="true" binding="HttpPost" relayStateUsedAsReturnUrl="true">
         <signingCertificate fileName="Sustainsys.Saml2.Tests.pfx"/>        
       </add>
     </identityProviders>

--- a/Tests/Tests.NETCore/App.config
+++ b/Tests/Tests.NETCore/App.config
@@ -34,6 +34,9 @@
       <add entityId="https://idp4.example.com" signOnUrl="https://idp4.example.com/idp" allowUnsolicitedAuthnResponse="false" binding="HttpPost" outboundSigningAlgorithm="sha256" wantAuthnRequestsSigned="true">
         <signingCertificate fileName="Sustainsys.Saml2.Tests.pfx"/>
       </add>
+      <add entityId="https://idp5.example.com" signOnUrl="https://idp5.example.com/idp" allowUnsolicitedAuthnResponse="true" binding="HttpPost" relayStateUsedAsRedirectUrl="true">
+        <signingCertificate fileName="Sustainsys.Saml2.Tests.pfx"/>        
+      </add>
     </identityProviders>
     <federations>
       <add metadataLocation="http://localhost:13428/federationMetadataSigned" allowUnsolicitedAuthnResponse="true">

--- a/Tests/Tests.NETFramework/App.config
+++ b/Tests/Tests.NETFramework/App.config
@@ -34,6 +34,9 @@
       <add entityId="https://idp4.example.com" signOnUrl="https://idp4.example.com/idp" allowUnsolicitedAuthnResponse="false" binding="HttpPost" outboundSigningAlgorithm="sha256" wantAuthnRequestsSigned="true">
         <signingCertificate fileName="Sustainsys.Saml2.Tests.pfx" />
       </add>
+      <add entityId="https://idp5.example.com" signOnUrl="https://idp5.example.com/idp" allowUnsolicitedAuthnResponse="true" binding="HttpPost" relayStateUsedAsRedirectUrl="true">
+        <signingCertificate fileName="Sustainsys.Saml2.Tests.pfx"/>
+      </add>
     </identityProviders>
     <federations>
       <add metadataLocation="http://localhost:13428/federationMetadataSigned" allowUnsolicitedAuthnResponse="true">

--- a/Tests/Tests.NETFramework/App.config
+++ b/Tests/Tests.NETFramework/App.config
@@ -34,7 +34,7 @@
       <add entityId="https://idp4.example.com" signOnUrl="https://idp4.example.com/idp" allowUnsolicitedAuthnResponse="false" binding="HttpPost" outboundSigningAlgorithm="sha256" wantAuthnRequestsSigned="true">
         <signingCertificate fileName="Sustainsys.Saml2.Tests.pfx" />
       </add>
-      <add entityId="https://idp5.example.com" signOnUrl="https://idp5.example.com/idp" allowUnsolicitedAuthnResponse="true" binding="HttpPost" relayStateUsedAsRedirectUrl="true">
+      <add entityId="https://idp5.example.com" signOnUrl="https://idp5.example.com/idp" allowUnsolicitedAuthnResponse="true" binding="HttpPost" relayStateUsedAsReturnUrl="true">
         <signingCertificate fileName="Sustainsys.Saml2.Tests.pfx"/>
       </add>
     </identityProviders>

--- a/Tests/Tests.Shared/WebSSO/AcsCommandTests.cs
+++ b/Tests/Tests.Shared/WebSSO/AcsCommandTests.cs
@@ -794,6 +794,6 @@ namespace Sustainsys.Saml2.Tests.WebSso
             Action a = () => new AcsCommand().Run(r, Options.FromConfiguration);
 
             a.Should().Throw<ConfigurationErrorsException>();
-        }
+        }        
     }
 }


### PR DESCRIPTION
Use the RelayState as the ReturnUrl when AllowUnsolicitedAuthnResponse is enabled. To keep compatibility and not break any current behaviour a new setting has been added to indicate that a ReturnUrl from the IDP is expected in the RelayState. This should be a fix for https://github.com/Sustainsys/Saml2/issues/250