### PR TITLE
Added support for "RequestAbstractType.Extensions" through notifications, issue #598

### DIFF
--- a/Sustainsys.Saml2/SAML2P/Saml2RequestBase.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2RequestBase.cs
@@ -82,10 +82,15 @@ namespace Sustainsys.Saml2.Saml2P
         /// </summary>
         public EntityId Issuer { get; set; }
 
-        /// <summary>
-        /// The SAML2 request name
-        /// </summary>
-        protected abstract string LocalName { get; }
+		/// <summary>
+		/// The additional content to append within an Extensions element.
+		/// </summary>
+		public List<XElement> ExtensionContents { get; } = new List<XElement>();
+
+		/// <summary>
+		/// The SAML2 request name
+		/// </summary>
+		protected abstract string LocalName { get; }
 
         /// <summary>
         /// Creates XNodes for the fields of the Saml2RequestBase class. These
@@ -109,7 +114,12 @@ namespace Sustainsys.Saml2.Saml2P
             {
                 yield return new XElement(Saml2Namespaces.Saml2 + "Issuer", Issuer.Id);
             }
-        }
+
+			if (ExtensionContents != null && ExtensionContents.Count > 0)
+			{
+				yield return new XElement(Saml2Namespaces.Saml2P + "Extensions", ExtensionContents);
+			}
+		}
 
         /// <summary>
         /// Reads the request properties present in Saml2RequestBase
@@ -136,7 +146,15 @@ namespace Sustainsys.Saml2.Saml2P
             {
                 Issuer = new EntityId(issuerNode.InnerXml);
             }
-        }
+
+			var extensionsNode = xml["Extensions", Saml2Namespaces.Saml2PName];
+			if (extensionsNode != null && extensionsNode.HasChildNodes)
+			{
+				XElement converted = XElement.Parse(extensionsNode.OuterXml);
+				ExtensionContents.Clear();
+				ExtensionContents.AddRange(converted.Elements());
+			}
+		}
 
         private void ValidateCorrectDocument(XmlElement xml)
         {

--- a/Tests/Tests.Shared/Saml2P/Saml2AuthenticationRequestTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2AuthenticationRequestTests.cs
@@ -80,7 +80,20 @@ namespace Sustainsys.Saml2.Tests.Saml2P
                 .Should().NotBeNull().And.Subject.Value.Should().Be("true");
         }
 
-        [TestMethod]
+		[TestMethod]
+		public void Saml2AuthenticationRequest_Extensions()
+		{
+			var request = new Saml2AuthenticationRequest();
+			request.ExtensionContents.Add(new XElement(XNamespace.Get("test") + "aditional"));
+			var subject = request.ToXElement();
+
+			subject.Should().NotBeNull().And.Subject
+				.Element(Saml2Namespaces.Saml2P + "Extensions").Should().NotBeNull().And.Subject
+				.Elements().Should().HaveCount(1).And.Subject
+				.First().Name.LocalName.Should().Be("aditional");
+		}
+
+		[TestMethod]
         public void Saml2AuthenticationRequest_Read()
         {
             var xmlData = @"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -218,7 +231,32 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             subject.NameIdPolicy.Format.Should().Be(NameIdFormat.NotConfigured);
         }
 
-        [TestMethod]
+		[TestMethod]
+		public void Saml2AuthenticationRequest_Read_Extensions()
+		{
+			var xmlData = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<samlp:AuthnRequest
+                     xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol""
+                     xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion""
+                     ID=""Saml2AuthenticationRequest_AssertionConsumerServiceUrl""
+                     Version=""2.0""
+                     Destination=""http://destination.example.com""
+                     AssertionConsumerServiceURL=""https://sp.example.com/SAML2/Acs""
+                     IssueInstant=""2004-12-05T09:21:59Z""
+                     ForceAuthn=""true"">
+    <saml:Issuer>https://sp.example.com/SAML2</saml:Issuer>
+    <samlp:Extensions>
+      <additional xmlns=""testurn:test"" />
+    </samlp:Extensions>
+</samlp:AuthnRequest>
+";
+
+			var subject = Saml2AuthenticationRequest.Read(xmlData, null);
+			subject.ExtensionContents.Should().HaveCount(1);
+			subject.ExtensionContents[0].ToString().Should().BeEquivalentTo(@"<additional xmlns=""testurn:test"" />");
+		}
+
+		[TestMethod]
         public void Saml2AuthenticationRequest_ToXElement_AddsElementSaml2NameIdPolicy_ForAllowCreate()
         {
             var subject = new Saml2AuthenticationRequest()


### PR DESCRIPTION
New re-implementation of pull request #600 using notifications for specifying content of Extensions element.