### PR TITLE
Make PostConfigureSaml2Options publicly accessible

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/PostConfigureSaml2Options.cs
+++ b/Sustainsys.Saml2.AspNetCore2/PostConfigureSaml2Options.cs
@@ -1,16 +1,11 @@
-﻿using Sustainsys.Saml2;
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Authentication;
 
 namespace Sustainsys.Saml2.AspNetCore2
 {
-    class PostConfigureSaml2Options : IPostConfigureOptions<Saml2Options>
+    public class PostConfigureSaml2Options : IPostConfigureOptions<Saml2Options>
     {
         private ILoggerFactory loggerFactory;
         private IOptions<AuthenticationOptions> authOptions;


### PR DESCRIPTION
Hello,

I would like to have the PostConfigureSaml2Options to be publicly accessible so that it can be registered and used in other projects. I've tested this solution and everything works as expected.

Thanks in advance.

Regards.
