### PR TITLE
Add support for EncryptedID

### DIFF
--- a/Sustainsys.Saml2/SAML2P/Saml2PSerializer.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2PSerializer.cs
@@ -223,8 +223,18 @@ namespace Sustainsys.Saml2.Saml2P
 					"EncryptedId could not be decrypted using any available decryption certificate");
 			}
 
-			reader = XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(decrypted.FirstChild));
+			reader = XmlDictionaryReader.CreateDictionaryReader(new XmlNodeReader(StripWrapper(decrypted)));
 			return ReadNameIdentifier(reader, null);
+		}
+
+		private static XmlNode StripWrapper(XmlElement decrypted)
+		{
+			var inner = decrypted.FirstChild;
+			while (!(inner is XmlElement) && inner != null)
+			{
+				inner = inner.NextSibling;
+			}
+			return inner;
 		}
 
 		public virtual void WriteEncryptedAssertion(XmlWriter writer, Saml2EncryptedAssertion assertion)

--- a/Tests/TestHelpers/SignedXmlHelper.cs
+++ b/Tests/TestHelpers/SignedXmlHelper.cs
@@ -88,7 +88,9 @@ namespace Sustainsys.Saml2.TestHelpers
             }
 
             var xmlDoc = XmlHelpers.CreateSafeXmlDocument();
-            var wrappedId = $@"<saml2:EncryptedID xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion"">{nameIdXml}</saml2:EncryptedID>";
+            var wrappedId = "<saml2:EncryptedID xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">\r\n"
+                            + $"    {nameIdXml}\r\n"  // the whitespace in this string is an important part of the test.
+                            + "</saml2:EncryptedID>";
             xmlDoc.LoadXml(wrappedId);
             var elementToEncrypt = (XmlElement)xmlDoc.GetElementsByTagName("NameID", Saml2Namespaces.Saml2Name)[0];
 

--- a/Tests/TestHelpers/SignedXmlHelper.cs
+++ b/Tests/TestHelpers/SignedXmlHelper.cs
@@ -80,6 +80,23 @@ namespace Sustainsys.Saml2.TestHelpers
             return xmlDoc.OuterXml;
         }
 
+        public static string EncryptId(string nameIdXml, bool useOaep = false, X509Certificate2 certificate = null)
+        {
+            if (certificate == null)
+            {
+                certificate = TestCert2;
+            }
+
+            var xmlDoc = XmlHelpers.CreateSafeXmlDocument();
+            var wrappedId = $@"<saml2:EncryptedID xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion"">{nameIdXml}</saml2:EncryptedID>";
+            xmlDoc.LoadXml(wrappedId);
+            var elementToEncrypt = (XmlElement)xmlDoc.GetElementsByTagName("NameID", Saml2Namespaces.Saml2Name)[0];
+
+            elementToEncrypt.Encrypt(useOaep, certificate);
+
+            return xmlDoc.OuterXml;
+        }
+
         public static readonly string KeyInfoXml;
 
         public static readonly string KeyInfoXml2;


### PR DESCRIPTION
See issue #528.  When an EncryptedID element appears in a SAML response, the deserialization fails with this error:

    NotSupportedException: IDX13140: EncryptedId is not supported. You will need to override ReadEncryptedId and provide support.

... so I have overridden that method, using similar decryption logic to what was already in ReadAssertion.  Should I also bump the version number to 2.3.0?

