### PR TITLE
Support multiple saml:AuthnStatement elements in Saml2Response.

### DIFF
--- a/Sustainsys.Saml2/SAML2P/Saml2Response.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2Response.cs
@@ -579,7 +579,9 @@ namespace Sustainsys.Saml2.Saml2P
 
 				sessionNotOnOrAfter = DateTimeHelper.EarliestTime(sessionNotOnOrAfter,
 					token.Assertion.Statements.OfType<Saml2AuthenticationStatement>()
-						.SingleOrDefault()?.SessionNotOnOrAfter);
+                        .Where(x => x.SessionNotOnOrAfter.HasValue)
+                        .OrderBy(x => x.SessionNotOnOrAfter)
+						.FirstOrDefault()?.SessionNotOnOrAfter);
 
 				foreach (var identity in principal.Identities)
 				{

--- a/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
@@ -2284,5 +2284,64 @@ namespace Sustainsys.Saml2.Tests.Saml2P
                 .Should().Throw<InvalidOperationException>()
                 .WithMessage("*GetClaims*");
         }
+
+
+        [TestMethod]
+        public void Saml2Response_CreateClaims_SupportsMultipleAuthnStatements()
+        {
+            var response =
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                <saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + $@"1""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"" />
+                    <saml2:AuthnStatement AuthnInstant=""{DateTime.UtcNow.ToSaml2DateTimeString()}"" SessionNotOnOrAfter = ""2050-01-01T00:00:00Z"">
+                        <saml2:AuthnContext>
+                            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>
+                        </saml2:AuthnContext>
+                    </saml2:AuthnStatement>
+                </saml2:Assertion>
+                <saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + $@"2""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeOtherUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"" />
+                    <saml2:AuthnStatement AuthnInstant=""{DateTime.UtcNow.ToSaml2DateTimeString()}"" SessionNotOnOrAfter = ""2051-01-01T00:00:00Z"">
+                        <saml2:AuthnContext>
+                            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>
+                        </saml2:AuthnContext>
+                    </saml2:AuthnStatement>
+                    <saml2:AuthnStatement AuthnInstant=""{DateTime.UtcNow.AddMinutes(2).ToSaml2DateTimeString()}"">
+                        <saml2:AuthnContext>
+                            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>
+                        </saml2:AuthnContext>
+                    </saml2:AuthnStatement>
+                    <saml2:AuthnStatement AuthnInstant=""{DateTime.UtcNow.AddMinutes(5).ToSaml2DateTimeString()}"" SessionNotOnOrAfter = ""2049-01-01T00:00:00Z"">
+                        <saml2:AuthnContext>
+                            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>
+                        </saml2:AuthnContext>
+                    </saml2:AuthnStatement>
+                </saml2:Assertion>
+            </saml2p:Response>";
+
+            Action a = () => Saml2Response.Read(SignedXmlHelper.SignXml(response)).GetClaims(StubFactory.CreateOptions());
+            a.Should().NotThrow();
+        }
     }
 }


### PR DESCRIPTION
I've ran into an issue while using the Saml2 library with the Nexus Hybrid Access Gateway where it sends multiple saml:AuthnStatement elements in the Saml2Response with all relevant user authentication contexts.

The code for getting SessionNotOnOrAfter was using SingleOrDefault which resulted in an exception being thrown.

This change filters out elements without the SessionNotOnOrAfter attribute as well as sorts by the earliest and uses FirstOrDefault instead.