### PR TITLE
Fixes issue #1064

### DIFF
--- a/Sustainsys.Saml2/Configuration/Saml2Notifications.cs
+++ b/Sustainsys.Saml2/Configuration/Saml2Notifications.cs
@@ -142,5 +142,12 @@ namespace Sustainsys.Saml2.Configuration
         /// </summary>
         public Func<EntityId, IDictionary<string, string>, IOptions, IdentityProvider> GetIdentityProvider { get; set; }
             = (ei, rd, opt) => opt.IdentityProviders[ei];
+
+        /// <summary>
+        /// Notification called when formatting redirect URL. Default version is to return
+        /// the detected current URL from the request.
+        /// </summary>
+        public Func<Uri, Uri, Uri> RewriteRedirectUrl { get; set; }
+            = (redirectUri, publicOrigin) => redirectUri;
     }
 }

--- a/Sustainsys.Saml2/WebSSO/SignInCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/SignInCommand.cs
@@ -111,6 +111,7 @@ namespace Sustainsys.Saml2.WebSso
             }
 
             var urls = new Saml2Urls(request, options);
+            returnPath = options.Notifications.RewriteRedirectUrl(new Uri(returnPath), urls.ApplicationUrl).ToString();
 
             IdentityProvider idp = options.Notifications.SelectIdentityProvider(idpEntityId, relayData);
             if (idp == null)

--- a/Sustainsys.Saml2/WebSSO/SignInCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/SignInCommand.cs
@@ -111,7 +111,10 @@ namespace Sustainsys.Saml2.WebSso
             }
 
             var urls = new Saml2Urls(request, options);
-            returnPath = options.Notifications.RewriteRedirectUrl(new Uri(returnPath), urls.ApplicationUrl).ToString();
+            if (!string.IsNullOrEmpty(returnPath))
+            {
+                returnPath = options.Notifications.RewriteRedirectUrl(new Uri(returnPath), urls.ApplicationUrl).ToString();
+            }
 
             IdentityProvider idp = options.Notifications.SelectIdentityProvider(idpEntityId, relayData);
             if (idp == null)

--- a/Sustainsys.Saml2/WebSSO/SignInCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/SignInCommand.cs
@@ -113,7 +113,7 @@ namespace Sustainsys.Saml2.WebSso
             var urls = new Saml2Urls(request, options);
             if (!string.IsNullOrEmpty(returnPath))
             {
-                returnPath = options.Notifications.RewriteRedirectUrl(new Uri(returnPath), urls.ApplicationUrl).ToString();
+                returnPath = options.Notifications.RewriteRedirectUrl(new Uri(returnPath, UriKind.RelativeOrAbsolute), urls.ApplicationUrl).ToString();
             }
 
             IdentityProvider idp = options.Notifications.SelectIdentityProvider(idpEntityId, relayData);


### PR DESCRIPTION
Saml2Handler for ASP.NET Core uses private property CurrentUri to determine where the application is running, and uses this as return url for SignIn command.

This does not work if the application is behind a reverse proxy, or running in Kubernetes or any other solution where you have TLS termination before reaching the application. 

In Kubernetes, for example, the requests will be:

Browser -> TLS terminating load balancer (https://domain/path) -> Pod (http://domain/path)
The application running inside the pod will determine that its URL is http://domain/path instead of https://domain/path causing a https to http downgrade. In reverse proxy scenarios, this will also affect the domain, and replace it with the reverse proxy address, instead of the public url (see issue #1064).

The fix (and to not break backwards compatibility) is to simply provide a Func to rewrite the redirect URL.
In most scenarios, the return url should be relative, not absolute. But so as not to break backwards compatibility, the Func can be used. Optionally, a flag could be put on options to indicate if we should strip the return url down to a relative URL instead. I still think this PR provides a good hook for other uses, so it shouldn't be replaced with the flag, but the default behavior of the Notifications Func could be made to respect the flag, so we don't need to manually convert the return url to a relative URL.

```
services.AddAuthentication(sharedOptions =>
{
    ...
}).AddSaml2(options =>
{
    // Converts http://pod:port/path to /path
    options.Notifications.RewriteRedirectUrl = (redirectUrl, publicUrl) => new Uri(redirectUrl.PathAndQuery, UriKind.Relative);
}
```