### PR TITLE
Errors when a querystring parameter contained an equals sign

### DIFF
--- a/Sustainsys.Saml2/Internal/QueryStringHelper.cs
+++ b/Sustainsys.Saml2/Internal/QueryStringHelper.cs
@@ -31,7 +31,19 @@ namespace Sustainsys.Saml2.Internal
 
             return queryString.Split('&')
                 .Where(x => !string.IsNullOrWhiteSpace(x))
-                .Select(x => x.Split('='))
+                .Select(x =>
+                {
+                    int indexOfFirstEqualsSign = x.IndexOf("=");
+                    if(indexOfFirstEqualsSign == -1)
+                    {
+                        return new string[] { x };
+                    }
+                    return new string[] 
+                    {
+                        x.Substring(0, indexOfFirstEqualsSign),
+                        x.Substring(indexOfFirstEqualsSign + 1)
+                    };
+                })
                 .ToLookup(y => y[0], y => y.Length > 1 ? Uri.UnescapeDataString(y[1]) : null);
         }
     }

--- a/Tests/Tests.Shared/Internal/QueryStringHelperTests.cs
+++ b/Tests/Tests.Shared/Internal/QueryStringHelperTests.cs
@@ -64,5 +64,33 @@ namespace Sustainsys.Saml2.Tests.Internal
 
             subject.Should().BeEquivalentTo(expected);
         }
+
+        [TestMethod]
+        public void QueryStringHelper_ParseQueryString_HandlesEqualsSignInParameter()
+        {
+            var subject = QueryStringHelper.ParseQueryString("?fname=john&lname=do=e");
+
+            var expected = new[]
+            {
+                new { key = "fname", value = "john" },
+                new { key = "lname", value="do=e" }
+            }.ToLookup(x => x.key, x => x.value);
+
+            subject.Should().BeEquivalentTo(expected);
+        }
+
+        [TestMethod]
+        public void QueryStringHelper_ParseQueryString_HandlesEqualsSignAtTheEndOfParameter()
+        {
+            var subject = QueryStringHelper.ParseQueryString("?fname=john&lname=doe=");
+
+            var expected = new[]
+            {
+                new { key = "fname", value = "john" },
+                new { key = "lname", value="doe=" }
+            }.ToLookup(x => x.key, x => x.value);
+
+            subject.Should().BeEquivalentTo(expected);
+        }
     }
 }


### PR DESCRIPTION
I was trying to make this library work with a third party identity provider. After entering my credentials I was redirected to: 'https://myurl.nl/Saml2/Acs?SAMLart=AAQAAM2K4swP9wWZMpSMawzmyp+75KEUTKD5z8M60TVvgpJFX5/6JdTuPKQ='. Notice the equals sign at the end of the url. QueryStringHelper.ParseQueryString removed the equals sign from the artifact which caused the BASE64 decoding to fail.