### PR TITLE
Fix link to BrowserFriendly Federation metadata.

### DIFF
--- a/Sustainsys.Saml2.StubIdp/Views/Shared/_Layout.cshtml
+++ b/Sustainsys.Saml2.StubIdp/Views/Shared/_Layout.cshtml
@@ -36,7 +36,7 @@
                     </a>
                     <ul class="dropdown-menu">
                         <li>@Html.ActionLink("Single Idp", "BrowserFriendly", "Metadata")</li>
-                        <li>@Html.ActionLink("Federation", "BrowswerFriendly", "Federation")</li>
+                        <li>@Html.ActionLink("Federation", "BrowserFriendly", "Federation")</li>
                     </ul>
                 </li>
                 <li class="dropdown">


### PR DESCRIPTION
Changing typo in the link from `"BrowswerFriendly"` -> `"BrowserFriendly"`, in the StubIdp project.