### PR TITLE
Do not modify shared options in Notifications test

### DIFF
--- a/Tests/Tests.Shared/WebSSO/SignInCommandTests.cs
+++ b/Tests/Tests.Shared/WebSSO/SignInCommandTests.cs
@@ -79,14 +79,15 @@ namespace Sustainsys.Saml2.Tests.WebSso
             var httpRequest = new HttpRequestData("GET", new Uri($"http://localhost/signin?ReturnUrl={absoluteUri}"));
             var validateAbsoluteReturnUrlCalled = false;
 
-            Options.FromConfiguration.Notifications.ValidateAbsoluteReturnUrl =
+            var options = StubFactory.CreateOptions();
+            options.Notifications.ValidateAbsoluteReturnUrl =
                 (url) =>
                 {
                     validateAbsoluteReturnUrlCalled = true;
                     return true;
                 };
             
-            Action a = () => new SignInCommand().Run(httpRequest, Options.FromConfiguration);
+            Action a = () => new SignInCommand().Run(httpRequest, options);
 
             a.Should().NotThrow<InvalidOperationException>("the ValidateAbsoluteReturnUrl notification returns true");
             validateAbsoluteReturnUrlCalled.Should().BeTrue("the ValidateAbsoluteReturnUrl notification should have been called");
@@ -100,14 +101,15 @@ namespace Sustainsys.Saml2.Tests.WebSso
             var httpRequest = new HttpRequestData("GET", new Uri($"http://localhost/signin?ReturnUrl={relativeUri}"));
             var validateAbsoluteReturnUrlCalled = false;
 
-            Options.FromConfiguration.Notifications.ValidateAbsoluteReturnUrl =
+            var options = StubFactory.CreateOptions();
+            options.Notifications.ValidateAbsoluteReturnUrl =
                 (url) =>
                 {
                     validateAbsoluteReturnUrlCalled = true;
                     return true;
                 };
 
-            Action a = () => new SignInCommand().Run(httpRequest, Options.FromConfiguration);
+            Action a = () => new SignInCommand().Run(httpRequest, options);
 
             a.Should().NotThrow<InvalidOperationException>("the ReturnUrl is relative");
             validateAbsoluteReturnUrlCalled.Should().BeFalse("the ValidateAbsoluteReturnUrl notification should not have been called");


### PR DESCRIPTION
These tests were modifying a shared options object and causing indeterminate results based on concurrent running of other tests. I'm not sure what changed (.Net 4.8? Visual Studio 2019?) to make them fail now but not earlier.