### PR TITLE
More informative exception for empty signature reference URI

### DIFF
--- a/Sustainsys.Saml2/XmlHelpers.cs
+++ b/Sustainsys.Saml2/XmlHelpers.cs
@@ -451,6 +451,10 @@ namespace Sustainsys.Saml2
             }
 
             var reference = (Reference)signedXml.SignedInfo.References[0];
+            if ( string.IsNullOrWhiteSpace( reference.Uri ) )
+            {
+                throw new InvalidSignatureException( "Empty reference for Xml signature is not allowed." );
+            }
             var id = reference.Uri.Substring(1);
 
 			var idElement = signedXml.GetIdElement(xmlElement.OwnerDocument, id);


### PR DESCRIPTION
Previous exception was:
`ArgumentOutOfRangeException with message "startIndex cannot be larger than length of string"`

When a partner sent a signature with `<ds:Reference URI="">`

Relevant section of SAML spec:
> **5.4.2 References** SAML assertions and protocol messages MUST supply a value for the ID attribute on the root element of the assertion or protocol message being signed. The assertion’s or protocol message's root element may or may not be the root element of the actual XML document containing the signed assertion or protocol message (e.g., it might be contained within a SOAP envelope). Signatures MUST contain a single <ds:Reference> containing a same-document reference to the ID attribute value of the root element of the assertion or protocol message being signed. For example, if the ID attribute value is "foo", then the URI attribute in the <ds:Reference> element MUST be "#foo". 