### PR TITLE
Meaningful exceptions for missing SamlResponse elements/attributes

### DIFF
--- a/Sustainsys.Saml2/SAML2P/Saml2Response.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2Response.cs
@@ -104,23 +104,24 @@ namespace Sustainsys.Saml2.Saml2P
 
             xmlElement = xml;
 
-            id = new Saml2Id(xml.Attributes["ID"].Value);
+            id = new Saml2Id(xml.GetRequiredAttributeValue("ID"));
 
             ReadAndValidateInResponseTo(xml, expectedInResponseTo, options);
 
-            issueInstant = DateTime.Parse(xml.Attributes["IssueInstant"].Value,
+            issueInstant = DateTime.Parse(xml.GetRequiredAttributeValue("IssueInstant"),
                 CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
 
-            var statusString = xml["Status", Saml2Namespaces.Saml2PName]
-                ["StatusCode", Saml2Namespaces.Saml2PName].Attributes["Value"].Value;
+            var statusElement = xml.GetRequiredElement("Status", Saml2Namespaces.Saml2PName);
+            var statusCodeElement = statusElement.GetRequiredElement("StatusCode", Saml2Namespaces.Saml2PName);
+            var statusString = statusCodeElement.GetRequiredAttributeValue("Value");
 
             status = StatusCodeHelper.FromString(statusString);
 
-            statusMessage = xml["Status", Saml2Namespaces.Saml2PName]
+            statusMessage = statusElement
                 ["StatusMessage", Saml2Namespaces.Saml2PName].GetTrimmedTextIfNotNull();
-            if (xml["Status", Saml2Namespaces.Saml2PName]["StatusCode", Saml2Namespaces.Saml2PName]["StatusCode", Saml2Namespaces.Saml2PName] != null)
+            if (statusCodeElement["StatusCode", Saml2Namespaces.Saml2PName] != null)
             {
-                secondLevelStatus = xml["Status", Saml2Namespaces.Saml2PName]["StatusCode", Saml2Namespaces.Saml2PName]["StatusCode", Saml2Namespaces.Saml2PName].Attributes["Value"].Value;
+                secondLevelStatus = statusCodeElement["StatusCode", Saml2Namespaces.Saml2PName].Attributes["Value"].Value;
             }
 
             Issuer = new EntityId(xmlElement["Issuer", Saml2Namespaces.Saml2Name].GetTrimmedTextIfNotNull());

--- a/Sustainsys.Saml2/XmlHelpers.cs
+++ b/Sustainsys.Saml2/XmlHelpers.cs
@@ -505,6 +505,28 @@ namespace Sustainsys.Saml2
             return xmlElement.InnerText.Trim();
         }
 
+        internal static string GetRequiredAttributeValue(this XmlElement node, string attributeName)
+        {
+            var foundAttribute = node.Attributes[attributeName];
+            if (string.IsNullOrWhiteSpace(foundAttribute?.Value))
+            {
+                throw new BadFormatSamlResponseException($"Attribute '{attributeName}' (case-sensitive) was not found or its value is empty");
+            }
+
+            return foundAttribute.Value;
+        }
+
+        internal static XmlElement GetRequiredElement(this XmlElement node, string name, string namespaceValue)
+        {
+            var foundElement = node[name, namespaceValue];
+            if (foundElement == null)
+            {
+                throw new BadFormatSamlResponseException($"Element '{name}' (case-sensitive, namespace '{namespaceValue}') was not found");
+            }
+
+            return foundElement;
+        }
+
         internal static XmlElement StartElement(this XmlNode parent, string name, Uri namespaceUri)
         {
             var xmlElement = parent.GetOwnerDoc().CreateElement(name, namespaceUri.OriginalString);

--- a/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
@@ -106,6 +106,95 @@ namespace Sustainsys.Saml2.Tests.Saml2P
         }
 
         [TestMethod]
+        public void Saml2Response_Read_ThrowsOnMissingId()
+        {
+            string responseText = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+                <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol"" Version=""2.0""
+                 IssueInstant=""2013-01-01T00:00:00Z"" InResponseTo = ""InResponseToId"" Destination=""http://destination.example.com"">
+                    <saml2p:Status>
+                        <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Requester"" />
+                        <saml2p:StatusMessage>Unable to encrypt assertion</saml2p:StatusMessage>
+                    </saml2p:Status>
+                </saml2p:Response>";
+
+            Action a = () => Saml2Response.Read( responseText );
+
+            a.Should().Throw<BadFormatSamlResponseException>()
+                .WithMessage( "Attribute 'ID' (case-sensitive) was not found or its value is empty" );
+        }
+
+        [TestMethod]
+        public void Saml2Response_Read_ThrowsOnEmptyId()
+        {
+            string responseText = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+                <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol"" Version=""2.0"" ID="" ""
+                 IssueInstant=""2013-01-01T00:00:00Z"" Destination=""http://destination.example.com"">
+                    <saml2p:Status>
+                        <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Requester"" />
+                        <saml2p:StatusMessage>Unable to encrypt assertion</saml2p:StatusMessage>
+                    </saml2p:Status>
+                </saml2p:Response>";
+
+            Action a = () => Saml2Response.Read( responseText );
+
+            a.Should().Throw<BadFormatSamlResponseException>()
+                .WithMessage( "Attribute 'ID' (case-sensitive) was not found or its value is empty" );
+        }
+
+        [TestMethod]
+        public void Saml2Response_Read_ThrowsOnMissingIssueInstant()
+        {
+            string responseText = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+                <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol"" Version=""2.0"" ID=""_abc123""
+                 Destination=""http://destination.example.com"">
+                    <saml2p:Status>
+                        <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Requester"" />
+                        <saml2p:StatusMessage>Unable to encrypt assertion</saml2p:StatusMessage>
+                    </saml2p:Status>
+                </saml2p:Response>";
+
+            Action a = () => Saml2Response.Read( responseText );
+
+            a.Should().Throw<BadFormatSamlResponseException>()
+                .WithMessage( "Attribute 'IssueInstant' (case-sensitive) was not found or its value is empty" );
+        }
+
+        [TestMethod]
+        public void Saml2Response_Read_ThrowsOnMissingStatus()
+        {
+            string responseText = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+                <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol"" Version=""2.0"" ID=""_abc123""
+                 IssueInstant=""2013-01-01T00:00:00Z"" Destination=""http://destination.example.com"">
+                    <Flatus>
+                        <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Requester"" />
+                        <saml2p:StatusMessage>Unable to encrypt assertion</saml2p:StatusMessage>
+                    </Flatus>
+                </saml2p:Response>";
+
+            Action a = () => Saml2Response.Read( responseText );
+
+            a.Should().Throw<BadFormatSamlResponseException>()
+                .WithMessage( "Element 'Status' (case-sensitive, namespace 'urn:oasis:names:tc:SAML:2.0:protocol') was not found" );
+        }
+
+        [TestMethod]
+        public void Saml2Response_Read_ThrowsOnMissingStatusCode()
+        {
+            string responseText = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+                <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol"" Version=""2.0"" ID=""_abc123""
+                 IssueInstant=""2013-01-01T00:00:00Z"" Destination=""http://destination.example.com"">
+                    <saml2p:Status>
+                        <saml2p:StatusMessage>Unable to encrypt assertion</saml2p:StatusMessage>
+                    </saml2p:Status>
+                </saml2p:Response>";
+
+            Action a = () => Saml2Response.Read( responseText );
+
+            a.Should().Throw<BadFormatSamlResponseException>()
+                .WithMessage( "Element 'StatusCode' (case-sensitive, namespace 'urn:oasis:names:tc:SAML:2.0:protocol') was not found" );
+        }
+
+        [TestMethod]
         public void Saml2Response_Read_ThrowsOnMalformedDestination()
         {
             var response =


### PR DESCRIPTION
I encountered some cases recently where I had to decipher from line numbers of `NullReferenceException` which part of the SAML was missing, and in some cases there are multiple possibilities for NRE per line.

This PR is an attempt to make integration testing with a new partner easier by getting clearer exceptions.