### PR TITLE
AspNetCore2: CommandFactory as a service, Command methods to virtual, some extension classes to public

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/CommandResultExtensions.cs
+++ b/Sustainsys.Saml2.AspNetCore2/CommandResultExtensions.cs
@@ -8,8 +8,20 @@ using System.Threading.Tasks;
 
 namespace Sustainsys.Saml2.AspNetCore2
 {
-    static class CommandResultExtensions
+    /// <summary>
+    /// Extensions for CommandResult.
+    /// </summary>
+    public static class CommandResultExtensions
     {
+        /// <summary>
+        /// Apply CommandResult.
+        /// </summary>
+        /// <param name="commandResult"></param>
+        /// <param name="httpContext"></param>
+        /// <param name="dataProtector"></param>
+        /// <param name="signInScheme"></param>
+        /// <param name="signOutScheme"></param>
+        /// <returns></returns>
         public static async Task Apply(
             this CommandResult commandResult,
             HttpContext httpContext,

--- a/Sustainsys.Saml2.AspNetCore2/HttpRequestExtensions.cs
+++ b/Sustainsys.Saml2.AspNetCore2/HttpRequestExtensions.cs
@@ -7,8 +7,17 @@ using System.Threading.Tasks;
 
 namespace Sustainsys.Saml2.AspNetCore2
 {
-    static class HttpRequestExtensions
+    /// <summary>
+    /// Extensions for HttpRequest.
+    /// </summary>
+    public static class HttpRequestExtensions
     {
+        /// <summary>
+        /// Convert HttpContext to HttpRequestData.
+        /// </summary>
+        /// <param name="httpContext"></param>
+        /// <param name="cookieDecryptor"></param>
+        /// <returns></returns>
         public static HttpRequestData ToHttpRequestData(
             this HttpContext httpContext,
             Func<byte[], byte[]> cookieDecryptor)

--- a/Sustainsys.Saml2.HttpModule/Saml2AuthenticationModule.cs
+++ b/Sustainsys.Saml2.HttpModule/Saml2AuthenticationModule.cs
@@ -63,7 +63,7 @@ namespace Sustainsys.Saml2.HttpModule
             {
                 var commandName = appRelativePath.Substring(modulePath.Length);
 
-                var command = CommandFactory.GetCommand(commandName);
+                var command = new CommandFactory().GetCommand(commandName);
                 var commandResult = command.Run(
                     new HttpRequestWrapper(application.Request).ToHttpRequestData(),
                     Options);

--- a/Sustainsys.Saml2.Mvc/Saml2Controller.cs
+++ b/Sustainsys.Saml2.Mvc/Saml2Controller.cs
@@ -42,7 +42,7 @@ namespace Sustainsys.Saml2.Mvc
         [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CommandResult")]
         public ActionResult SignIn()
         {
-            var result = CommandFactory.GetCommand(CommandFactory.SignInCommandName).Run(
+            var result = new CommandFactory().GetCommand(CommandFactory.SignInCommandName).Run(
                 Request.ToHttpRequestData(),
                 Options);
 
@@ -66,7 +66,7 @@ namespace Sustainsys.Saml2.Mvc
         [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CommandResult")]
         public ActionResult Acs()
         {
-            var result = CommandFactory.GetCommand(CommandFactory.AcsCommandName).Run(
+            var result = new CommandFactory().GetCommand(CommandFactory.AcsCommandName).Run(
                 Request.ToHttpRequestData(),
                 Options);
 
@@ -88,7 +88,7 @@ namespace Sustainsys.Saml2.Mvc
         [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CommandResult")]
         public ActionResult Index()
         {
-            var result = CommandFactory.GetCommand(CommandFactory.MetadataCommand).Run(
+            var result = new CommandFactory().GetCommand(CommandFactory.MetadataCommand).Run(
                 Request.ToHttpRequestData(),
                 Options);
 
@@ -111,7 +111,7 @@ namespace Sustainsys.Saml2.Mvc
         [SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout")]
         public ActionResult Logout()
         {
-            var result = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var result = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(Request.ToHttpRequestData(), Options);
 
             if (result.HandledResult)

--- a/Sustainsys.Saml2.Owin/Saml2AuthenticationHandler.cs
+++ b/Sustainsys.Saml2.Owin/Saml2AuthenticationHandler.cs
@@ -29,7 +29,7 @@ namespace Sustainsys.Saml2.Owin
             var httpRequestData = await Context.ToHttpRequestData(Options.DataProtector.Unprotect);
             try
             {
-                var result = CommandFactory.GetCommand(CommandFactory.AcsCommandName)
+                var result = new CommandFactory().GetCommand(CommandFactory.AcsCommandName)
                     .Run(httpRequestData, Options);
 
                 if (!result.HandledResult)
@@ -204,7 +204,7 @@ namespace Sustainsys.Saml2.Owin
 
                 try
                 {
-                    var result = CommandFactory.GetCommand(remainingPath.Value)
+                    var result = new CommandFactory().GetCommand(remainingPath.Value)
                         .Run(await Context.ToHttpRequestData(Options.DataProtector.Unprotect), Options);
 
                     if (!result.HandledResult)

--- a/Sustainsys.Saml2/WebSSO/AcsCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/AcsCommand.cs
@@ -17,7 +17,7 @@ namespace Sustainsys.Saml2.WebSso
     /// <summary>
     /// Represents the assertion consumer service command behaviour.
     /// Instances of this class can be created directly or by using the factory method
-    /// CommandFactory.GetCommand(CommandFactory.AcsCommandName).
+    /// new CommandFactory().GetCommand(CommandFactory.AcsCommandName).
     /// </summary>
     public class AcsCommand : ICommand
     {
@@ -27,7 +27,7 @@ namespace Sustainsys.Saml2.WebSso
         /// <param name="request">Request data.</param>
         /// <param name="options">Options</param>
         /// <returns>CommandResult</returns>
-        public CommandResult Run(HttpRequestData request, IOptions options)
+        public virtual CommandResult Run(HttpRequestData request, IOptions options)
         {
             if(request == null)
             {

--- a/Sustainsys.Saml2/WebSSO/CommandFactory.cs
+++ b/Sustainsys.Saml2/WebSSO/CommandFactory.cs
@@ -10,7 +10,7 @@ namespace Sustainsys.Saml2.WebSso
     /// <summary>
     /// Factory to create the command objects thand handles the incoming http requests.
     /// </summary>
-    public static class CommandFactory
+    public class CommandFactory : ICommandFactory
     {
         private static readonly ICommand notFoundCommand = new NotFoundCommand();
 
@@ -51,7 +51,7 @@ namespace Sustainsys.Saml2.WebSso
         /// <param name="commandName">Name of a command. Probably a path. A
         /// leading slash in the command name is ignored.</param>
         /// <returns>A command implementation or notFoundCommand if invalid.</returns>
-        public static ICommand GetCommand(string commandName)
+        public ICommand GetCommand(string commandName)
         {
             ICommand command;
 

--- a/Sustainsys.Saml2/WebSSO/ICommandFactory.cs
+++ b/Sustainsys.Saml2/WebSSO/ICommandFactory.cs
@@ -1,0 +1,10 @@
+﻿namespace Sustainsys.Saml2.WebSso
+{
+    /// <summary>
+    /// Interface for a factory that creates the command objects that handle the incoming http requests.
+    /// </summary>
+    public interface ICommandFactory
+    {
+        ICommand GetCommand(string commandName);
+    }
+}

--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -16,7 +16,7 @@ namespace Sustainsys.Saml2.WebSso
     /// <summary>
     /// Represents the logout command behaviour.
     /// Instances of this class can be created directly or by using the factory method
-    /// CommandFactory.GetCommand(CommandFactory.LogoutCommandName).
+    /// new CommandFactory().GetCommand(CommandFactory.LogoutCommandName).
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout")]
     public class LogoutCommand : ICommand
@@ -27,7 +27,7 @@ namespace Sustainsys.Saml2.WebSso
         /// <param name="request">Request data.</param>
         /// <param name="options">Options</param>
         /// <returns>CommandResult</returns>
-        public CommandResult Run(HttpRequestData request, IOptions options)
+        public virtual CommandResult Run(HttpRequestData request, IOptions options)
         {
             if(request == null)
             {

--- a/Sustainsys.Saml2/WebSSO/MetadataCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/MetadataCommand.cs
@@ -14,7 +14,7 @@ namespace Sustainsys.Saml2.WebSso
     /// <summary>
     /// Represents the service provider metadata command behaviour.
     /// Instances of this class can be created directly or by using the factory method
-    /// CommandFactory.GetCommand(CommandFactory.MetadataCommandName).
+    /// new CommandFactory().GetCommand(CommandFactory.MetadataCommandName).
     /// </summary>
     public class MetadataCommand : ICommand
     {
@@ -24,7 +24,7 @@ namespace Sustainsys.Saml2.WebSso
         /// <param name="request">Request data.</param>
         /// <param name="options">Options</param>
         /// <returns>CommandResult</returns>
-        public CommandResult Run(HttpRequestData request, IOptions options)
+        public virtual CommandResult Run(HttpRequestData request, IOptions options)
         {
             if(options == null)
             {

--- a/Sustainsys.Saml2/WebSSO/NotFoundCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/NotFoundCommand.cs
@@ -9,7 +9,7 @@ namespace Sustainsys.Saml2.WebSso
 {
     /// <summary>
     /// Represents a missing command.
-    /// Instances of this class are returned by CommandFactory.GetCommand(...)
+    /// Instances of this class are returned by new CommandFactory().GetCommand(...)
     /// when the specified command name is not recognised.
     /// </summary>
     public class NotFoundCommand : ICommand
@@ -20,7 +20,7 @@ namespace Sustainsys.Saml2.WebSso
         /// <param name="request">Request data.</param>
         /// <param name="options">Options</param>
         /// <returns>CommandResult</returns>
-        public CommandResult Run(HttpRequestData request, IOptions options)
+        public virtual CommandResult Run(HttpRequestData request, IOptions options)
         {
             return new CommandResult()
             {

--- a/Sustainsys.Saml2/WebSSO/SignInCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/SignInCommand.cs
@@ -12,7 +12,7 @@ namespace Sustainsys.Saml2.WebSso
     /// <summary>
     /// Represents the sign in command behaviour.
     /// Instances of this class can be created directly or by using the factory method
-    /// CommandFactory.GetCommand(CommandFactory.SignInCommandName).
+    /// new CommandFactory().GetCommand(CommandFactory.SignInCommandName).
     /// </summary>
     public class SignInCommand : ICommand
     {
@@ -22,7 +22,7 @@ namespace Sustainsys.Saml2.WebSso
         /// <param name="request">Request data.</param>
         /// <param name="options">Options</param>
         /// <returns>CommandResult</returns>
-        public CommandResult Run(HttpRequestData request, IOptions options)
+        public virtual CommandResult Run(HttpRequestData request, IOptions options)
         {
             if (request == null)
             {

--- a/Tests/Tests.Shared/WebSSO/CommandFactoryTests.cs
+++ b/Tests/Tests.Shared/WebSSO/CommandFactoryTests.cs
@@ -11,49 +11,49 @@ namespace Sustainsys.Saml2.Tests.WebSso
         [TestMethod]
         public void CommandFactory_GetCommand_Invalid_ReturnsNotFound()
         {
-            CommandFactory.GetCommand("Invalid").Should().BeOfType<NotFoundCommand>();
+            new CommandFactory().GetCommand("Invalid").Should().BeOfType<NotFoundCommand>();
         }
 
         [TestMethod]
         public void CommandFactory_GetCommand_SignIn_ReturnsSignIn()
         {
-            CommandFactory.GetCommand("SignIn").Should().BeOfType<SignInCommand>();
+            new CommandFactory().GetCommand("SignIn").Should().BeOfType<SignInCommand>();
         }
 
         [TestMethod]
         public void CommandFactory_GetCommand_IsCaseInsensitive()
         {
-          CommandFactory.GetCommand("signin").Should().BeOfType<SignInCommand>();
+          new CommandFactory().GetCommand("signin").Should().BeOfType<SignInCommand>();
         }
 
         [TestMethod]
         public void CommandFactory_GetCommand_Acs_ReturnsAcs()
         {
-            CommandFactory.GetCommand("Acs").Should().BeOfType<AcsCommand>();
+            new CommandFactory().GetCommand("Acs").Should().BeOfType<AcsCommand>();
         }
 
         [TestMethod]
         public void CommandFactory_GetCommand_Root_ReturnsMetadata()
         {
-            CommandFactory.GetCommand("").Should().BeOfType<MetadataCommand>();
+            new CommandFactory().GetCommand("").Should().BeOfType<MetadataCommand>();
         }
 
         [TestMethod]
         public void CommnandFactory_GetCommand_StripsOffLeadingSlash()
         {
-            CommandFactory.GetCommand("/Acs").Should().BeOfType<AcsCommand>();
+            new CommandFactory().GetCommand("/Acs").Should().BeOfType<AcsCommand>();
         }
 
         [TestMethod]
         public void CommandFactory_GetCommand_SignOut_ReturnsSignOut()
         {
-            CommandFactory.GetCommand("Logout").Should().BeOfType<LogoutCommand>();
+            new CommandFactory().GetCommand("Logout").Should().BeOfType<LogoutCommand>();
         }
 
         [TestMethod]
         public void CommandFactory_GetCommand_NullCheckCommandName()
         {
-            Action a = () => CommandFactory.GetCommand(null);
+            Action a = () => new CommandFactory().GetCommand(null);
 
             a.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("commandName");
         }

--- a/Tests/Tests.Shared/WebSSO/LogoutCommandTests.cs
+++ b/Tests/Tests.Shared/WebSSO/LogoutCommandTests.cs
@@ -42,7 +42,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
         [TestMethod]
         public void LogoutCommand_InstanceRun_NullcheckRequest()
         {
-            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Invoking(c => c.Run(null, StubFactory.CreateOptions()))
                 .Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("request");
@@ -69,7 +69,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
         [TestMethod]
         public void LogoutCommand_Run_NullcheckOptions()
         {
-            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Invoking(c => c.Run(new HttpRequestData("GET", new Uri("http://localhost")), null))
                 .Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("options");
@@ -98,7 +98,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
                 notifiedCommandResult = cr;
             };
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(request, options);
 
             actual.Should().BeSameAs(notifiedCommandResult);
@@ -146,7 +146,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             options.IdentityProviders[new EntityId("https://idp.example.com")]
                 .SingleLogoutServiceBinding = Saml2BindingType.HttpPost;
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(request, options);
 
             actual.HttpStatusCode.Should().Be(HttpStatusCode.OK);
@@ -170,7 +170,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             options.SPOptions.PublicOrigin = new Uri("https://sp.example.com/");
             options.SPOptions.Compatibility.DisableLogoutStateCookie = true;
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(request, options);
 
             var relayState = HttpUtility.ParseQueryString(actual.Location.Query)["RelayState"];
@@ -195,7 +195,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             var options = StubFactory.CreateOptions();
             options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(request, options);
 
             actual.RequestState.ReturnUrl.OriginalString.Should().Be("/LoggedOut");
@@ -208,7 +208,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             var request = new HttpRequestData("GET", new Uri($"http://sp.example.com/Saml2/Logout?ReturnUrl={absoluteUri}"));
             var options = StubFactory.CreateOptions();
 
-            Action a = () => CommandFactory.GetCommand(CommandFactory.LogoutCommandName).Run(request, options);
+            Action a = () => new CommandFactory().GetCommand(CommandFactory.LogoutCommandName).Run(request, options);
             a.Should().Throw<InvalidOperationException>().WithMessage("Return Url must be a relative Url.");
         }
 
@@ -219,7 +219,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             var request = new HttpRequestData("GET", new Uri($"http://sp.example.com/Saml2/Logout?ReturnUrl={absoluteUri}"));
             var options = StubFactory.CreateOptions();
 
-            Action a = () => CommandFactory.GetCommand(CommandFactory.LogoutCommandName).Run(request, options);
+            Action a = () => new CommandFactory().GetCommand(CommandFactory.LogoutCommandName).Run(request, options);
             a.Should().Throw<InvalidOperationException>().WithMessage("Return Url must be a relative Url.");
         }
 
@@ -239,7 +239,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
                     return true;
                 };
 
-            Action a = () => CommandFactory.GetCommand(CommandFactory.LogoutCommandName).Run(request, options);
+            Action a = () => new CommandFactory().GetCommand(CommandFactory.LogoutCommandName).Run(request, options);
             a.Should().NotThrow<InvalidOperationException>("the ValidateAbsoluteReturnUrl notification returns true");
             validateAbsoluteReturnUrlCalled.Should().BeTrue("the ValidateAbsoluteReturnUrl notification should have been called");
         }
@@ -260,7 +260,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
                     return true;
                 };
 
-            Action a = () => CommandFactory.GetCommand(CommandFactory.LogoutCommandName).Run(request, options);
+            Action a = () => new CommandFactory().GetCommand(CommandFactory.LogoutCommandName).Run(request, options);
             a.Should().NotThrow<InvalidOperationException>("the ReturnUrl is relative");
             validateAbsoluteReturnUrlCalled.Should().BeFalse("the ValidateAbsoluteReturnUrl notification should not have been called");
         }
@@ -288,7 +288,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             var options = StubFactory.CreateOptions();
             options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(request, options);
 
             var expected = new CommandResult
@@ -349,7 +349,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
                 responseUnboundCalled = true;
             };
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(request, options);
 
             actual.Should().BeSameAs(notifiedCommandResult);
@@ -399,7 +399,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             var options = StubFactory.CreateOptions();
             options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(httpRequest, options);
 
             var expected = new CommandResult
@@ -446,7 +446,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             dummyIdp.SigningKeys.AddConfiguredKey(SignedXmlHelper.TestCert);
             options.IdentityProviders.Add(dummyIdp);
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(httpRequest, options);
 
             var expected = new CommandResult()
@@ -521,7 +521,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             var options = StubFactory.CreateOptions();
             options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(httpRequest, options);
 
             HttpUtility.ParseQueryString(actual.Location.Query)
@@ -561,7 +561,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             options.SPOptions.MinIncomingSigningAlgorithm = SecurityAlgorithms.RsaSha384Signature;
             options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
 
-            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Invoking(c => c.Run(httpRequest, options))
                 .Should().Throw<InvalidSignatureException>()
                 .WithMessage("*weak*");
@@ -599,7 +599,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
             options.SPOptions.ValidateCertificates = true;
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Invoking(c => c.Run(httpRequest, options))
                 .Should().Throw<InvalidSignatureException>()
                 .WithMessage("The signature was valid, but the verification of the certificate failed. Is it expired or revoked? Are you sure you really want to enable ValidateCertificates (it's normally not needed)?");
@@ -625,7 +625,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
 
             var options = StubFactory.CreateOptions();
 
-            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Invoking(c => c.Run(httpRequest, options))
                 .Should().Throw<ConfigurationErrorsException>()
                 .WithMessage("Received a LogoutRequest from \"https://idp.example.com\" but cannot reply because single logout responses must be signed and there is no signing certificate configured. Looks like the idp is configured for Single Logout despite Saml2 not exposing that functionality in the metadata.");
@@ -652,7 +652,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             var options = StubFactory.CreateOptions();
             options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
 
-            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Invoking(c => c.Run(httpRequest, options))
                 .Should().Throw<InvalidOperationException>()
                 .WithMessage("*LogoutRequest*\"https://idp2.example.com\"*cannot reply*logout endpoint*idp*");
@@ -677,7 +677,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             var options = StubFactory.CreateOptions();
             options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
 
-            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Invoking(c => c.Run(httpRequest, options))
                 .Should().Throw<UnsuccessfulSamlOperationException>()
                 .WithMessage("Received a LogoutRequest from https://idp.example.com that cannot be processed because it is not signed.");
@@ -705,7 +705,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             var options = StubFactory.CreateOptions();
             options.SPOptions.PublicOrigin = new Uri("https://sp.example.com/path/");
 
-            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Invoking(c => c.Run(request, options))
                 .Should().Throw<UnsuccessfulSamlOperationException>()
                 .And.Message.Should().Be("Idp returned status \"Requester\", indicating that the single logout failed. The local session has been successfully terminated.");
@@ -733,7 +733,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             options.SPOptions.PublicOrigin = new Uri("https://sp.example.com/path/");
             options.Notifications.ProcessSingleLogoutResponseStatus = (logoutResponse, requestState) => true;
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName).Run(request, options);
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName).Run(request, options);
             actual.Location.Should().BeEquivalentTo(options.SPOptions.PublicOrigin);
         }
 
@@ -764,7 +764,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
 
         private void LogoutCommand_Run_LocalLogout(IOptions options, ClaimsPrincipal user)
         {
-            var subject = CommandFactory.GetCommand(CommandFactory.LogoutCommandName);
+            var subject = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName);
                        
             var actual = subject.Run(
                 new HttpRequestData("GET", new Uri("http://localhost/Logout?ReturnUrl=%2FLoggedOut"))
@@ -898,7 +898,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
 
             var request = new HttpRequestData("GET", url);
 
-            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Invoking(c => c.Run(request, StubFactory.CreateOptions()))
                 .Should().Throw<NotImplementedException>();
         }
@@ -919,7 +919,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
 
             var request = new HttpRequestData("GET", url);
 
-            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Invoking(c => c.Run(request, StubFactory.CreateOptions()))
                 .Should().Throw<InvalidSignatureException>()
                 .WithMessage("There is no Issuer element in the message, so there is no way to know what certificate to use to validate the signature.");
@@ -961,7 +961,7 @@ namespace Sustainsys.Saml2.Tests.WebSSO
             var options = StubFactory.CreateOptions();
             options.SPOptions.Compatibility.DisableLogoutStateCookie = true;
 
-            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+            var actual = new CommandFactory().GetCommand(CommandFactory.LogoutCommandName)
                 .Run(request, options);
 
             var expected = new CommandResult

--- a/Tests/Tests.Shared/WebSSO/SignInCommandTests.cs
+++ b/Tests/Tests.Shared/WebSSO/SignInCommandTests.cs
@@ -335,7 +335,7 @@ namespace Sustainsys.Saml2.Tests.WebSso
                 RelayState = relayState
             };
 
-            var subject = CommandFactory.GetCommand(CommandFactory.SignInCommandName);
+            var subject = new CommandFactory().GetCommand(CommandFactory.SignInCommandName);
 
             var actual = subject.Run(request, options);
 
@@ -376,7 +376,7 @@ namespace Sustainsys.Saml2.Tests.WebSso
                 RelayState = relayState
             };
 
-            var subject = CommandFactory.GetCommand(CommandFactory.SignInCommandName);
+            var subject = new CommandFactory().GetCommand(CommandFactory.SignInCommandName);
 
             var actual = subject.Run(request, options);
 
@@ -393,7 +393,7 @@ namespace Sustainsys.Saml2.Tests.WebSso
 
             var request = new HttpRequestData("GET", uri);
 
-            var subject = CommandFactory.GetCommand(CommandFactory.SignInCommandName);
+            var subject = new CommandFactory().GetCommand(CommandFactory.SignInCommandName);
 
             subject.Invoking(s => s.Run(request, StubFactory.CreateOptions()))
                 .Should().Throw<InvalidOperationException>().


### PR DESCRIPTION
These non-breaking changes allow for convenient overriding of default command implementations.

With these changes, you can use add your own ICommandFactory as a service to instantiate e.g. your own Acs command. Command methods are changed to virtual. That allows you to inherit default command implementations and selectively override their methods.

Some extension classes are changed to public to allow you to reuse them.