### PR TITLE
Support for IsPassive added to SAML request

### DIFF
--- a/Sustainsys.Saml2/IdentityProvider.cs
+++ b/Sustainsys.Saml2/IdentityProvider.cs
@@ -291,8 +291,7 @@ namespace Sustainsys.Saml2
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AuthenticateRequestSigningBehavior")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ServiceCertificates")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AuthenticateRequests")]
-        public Saml2AuthenticationRequest CreateAuthenticateRequest(
-            Saml2Urls saml2Urls, HttpRequestData request)
+        public Saml2AuthenticationRequest CreateAuthenticateRequest(Saml2Urls saml2Urls)
         {
             if (saml2Urls == null)
             {
@@ -310,18 +309,6 @@ namespace Sustainsys.Saml2
                 RequestedAuthnContext = spOptions.RequestedAuthnContext,
                 SigningAlgorithm = this.OutboundSigningAlgorithm
             };
-
-            var forceAuthnString = request.QueryString["ForceAuthn"].SingleOrDefault();
-            if (!string.IsNullOrWhiteSpace(forceAuthnString))
-            {
-                authnRequest.ForceAuthentication = bool.Parse(forceAuthnString);
-            }
-
-            var isPassiveString = request.QueryString["IsPassive"].SingleOrDefault();
-            if (!string.IsNullOrWhiteSpace(isPassiveString))
-            {
-                authnRequest.IsPassive = bool.Parse(isPassiveString);
-            }
 
             if (spOptions.AuthenticateRequestSigningBehavior == SigningBehavior.Always
                 || (spOptions.AuthenticateRequestSigningBehavior == SigningBehavior.IfIdpWantAuthnRequestsSigned

--- a/Sustainsys.Saml2/IdentityProvider.cs
+++ b/Sustainsys.Saml2/IdentityProvider.cs
@@ -1,20 +1,18 @@
-﻿using System.Collections.Generic;
-using Sustainsys.Saml2.Configuration;
-using System;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Configuration;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Security.Cryptography;
-using Sustainsys.Saml2.Internal;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Sustainsys.Saml2.Configuration;
 using Sustainsys.Saml2.Metadata;
 using Sustainsys.Saml2.Saml2P;
-using Sustainsys.Saml2.WebSso;
-using System.Threading.Tasks;
-using System.Net;
-using System.Collections.Concurrent;
-using System.Security.Claims;
-using System.Diagnostics.CodeAnalysis;
 using Sustainsys.Saml2.Tokens;
+using Sustainsys.Saml2.WebSso;
 
 namespace Sustainsys.Saml2
 {
@@ -289,11 +287,12 @@ namespace Sustainsys.Saml2
         /// </summary>
         /// <param name="saml2Urls">Urls for Saml2, used to populate fields
         /// in the created AuthnRequest</param>
+        /// <param name="request">The incoming http request.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AuthenticateRequestSigningBehavior")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ServiceCertificates")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "AuthenticateRequests")]
         public Saml2AuthenticationRequest CreateAuthenticateRequest(
-            Saml2Urls saml2Urls)
+            Saml2Urls saml2Urls, HttpRequestData request)
         {
             if (saml2Urls == null)
             {
@@ -311,6 +310,18 @@ namespace Sustainsys.Saml2
                 RequestedAuthnContext = spOptions.RequestedAuthnContext,
                 SigningAlgorithm = this.OutboundSigningAlgorithm
             };
+
+            var forceAuthnString = request.QueryString["ForceAuthn"].SingleOrDefault();
+            if (!string.IsNullOrWhiteSpace(forceAuthnString))
+            {
+                authnRequest.ForceAuthentication = bool.Parse(forceAuthnString);
+            }
+
+            var isPassiveString = request.QueryString["IsPassive"].SingleOrDefault();
+            if (!string.IsNullOrWhiteSpace(isPassiveString))
+            {
+                authnRequest.IsPassive = bool.Parse(isPassiveString);
+            }
 
             if (spOptions.AuthenticateRequestSigningBehavior == SigningBehavior.Always
                 || (spOptions.AuthenticateRequestSigningBehavior == SigningBehavior.IfIdpWantAuthnRequestsSigned
@@ -441,11 +452,11 @@ namespace Sustainsys.Saml2
 
             foreach (var kv in idpDescriptor.ArtifactResolutionServices)
             {
-				var ars = kv.Value;
+                var ars = kv.Value;
                 artifactResolutionServiceUrls[ars.Index] = ars.Location;
             }
 
-			var arsKeys = idpDescriptor.ArtifactResolutionServices.ToLookup(x => x.Value.Index);
+            var arsKeys = idpDescriptor.ArtifactResolutionServices.ToLookup(x => x.Value.Index);
             foreach (var ars in artifactResolutionServiceUrls.Keys
                 .Where(k => !arsKeys.Contains(k)))
             {
@@ -455,7 +466,7 @@ namespace Sustainsys.Saml2
             var keys = idpDescriptor.Keys.Where(k => k.Use == KeyType.Unspecified || k.Use == KeyType.Signing);
 
             signingKeys.SetLoadedItems(keys.Select(k => k.KeyInfo
-				.MakeSecurityKeyIdentifier().First(c => c.CanCreateKey)).ToList());
+                .MakeSecurityKeyIdentifier().First(c => c.CanCreateKey)).ToList());
         }
 
         private static T GetPreferredEndpoint<T>(ICollection<T> endpoints) where T : Endpoint
@@ -506,7 +517,7 @@ namespace Sustainsys.Saml2
         private static void DoLoadMetadataIfTargetAlive(WeakReference<IdentityProvider> target)
         {
             IdentityProvider idp;
-            if(target.TryGetTarget(out idp))
+            if (target.TryGetTarget(out idp))
             {
                 idp.DoLoadMetadata();
             }

--- a/Sustainsys.Saml2/SAML2P/Saml2AuthenticationRequest.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2AuthenticationRequest.cs
@@ -53,6 +53,10 @@ namespace Sustainsys.Saml2.Saml2P
             {
                 x.Add(new XAttribute("ForceAuthn", ForceAuthentication));
             }
+            if (IsPassive)
+            {
+                x.Add(new XAttribute("IsPassive", IsPassive));
+            }
 
             AddNameIdPolicy(x);
 
@@ -161,6 +165,12 @@ namespace Sustainsys.Saml2.Saml2P
                 ForceAuthentication = bool.Parse(forceAuthnString);
             }
 
+            var isPassiveString = xml.Attributes["IsPassive"].GetValueIfNotNull();
+            if (isPassiveString != null)
+            {
+                IsPassive = bool.Parse(isPassiveString);
+            }
+
             var node = xml["NameIDPolicy", Saml2Namespaces.Saml2PName];
             if (node != null)
             {
@@ -220,5 +230,12 @@ namespace Sustainsys.Saml2.Saml2P
         /// If true, the request is sent with ForceAuthn="true".
         /// </summary>
         public bool ForceAuthentication { get; set; } = false;
+
+        /// <summary>
+        /// Sets whether request should request for SAML Passive login if possible, 
+        /// If false, the IsPassive parameter is omitted from the request.
+        /// If true, the request is sent with IsPassive="true".
+        /// </summary>
+        public bool IsPassive { get; set; } = false;
     }
 }

--- a/Sustainsys.Saml2/WebSSO/SignInCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/SignInCommand.cs
@@ -1,9 +1,9 @@
-﻿using Sustainsys.Saml2.Configuration;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using Sustainsys.Saml2.Configuration;
 using Sustainsys.Saml2.Internal;
 using Sustainsys.Saml2.Metadata;
 
@@ -144,12 +144,12 @@ namespace Sustainsys.Saml2.WebSso
                 : new Uri(returnPath, UriKind.RelativeOrAbsolute);
 
             options.SPOptions.Logger.WriteInformation("Initiating login to " + idp.EntityId.Id);
-            return InitiateLoginToIdp(options, relayData, urls, idp, returnUrl);
+            return InitiateLoginToIdp(options, relayData, urls, idp, returnUrl, request);
         }
 
-        private static CommandResult InitiateLoginToIdp(IOptions options, IDictionary<string, string> relayData, Saml2Urls urls, IdentityProvider idp, Uri returnUrl)
+        private static CommandResult InitiateLoginToIdp(IOptions options, IDictionary<string, string> relayData, Saml2Urls urls, IdentityProvider idp, Uri returnUrl, HttpRequestData request)
         {
-            var authnRequest = idp.CreateAuthenticateRequest(urls);
+            var authnRequest = idp.CreateAuthenticateRequest(urls, request);
 
             options.Notifications.AuthenticationRequestCreated(authnRequest, idp, relayData);
 

--- a/Sustainsys.Saml2/WebSSO/SignInCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/SignInCommand.cs
@@ -149,7 +149,19 @@ namespace Sustainsys.Saml2.WebSso
 
         private static CommandResult InitiateLoginToIdp(IOptions options, IDictionary<string, string> relayData, Saml2Urls urls, IdentityProvider idp, Uri returnUrl, HttpRequestData request)
         {
-            var authnRequest = idp.CreateAuthenticateRequest(urls, request);
+            var authnRequest = idp.CreateAuthenticateRequest(urls);
+
+            var forceAuthnString = request.QueryString["ForceAuthn"].SingleOrDefault();
+            if (!string.IsNullOrWhiteSpace(forceAuthnString))
+            {
+                authnRequest.ForceAuthentication = bool.Parse(forceAuthnString);
+            }
+
+            var isPassiveString = request.QueryString["IsPassive"].SingleOrDefault();
+            if (!string.IsNullOrWhiteSpace(isPassiveString))
+            {
+                authnRequest.IsPassive = bool.Parse(isPassiveString);
+            }
 
             options.Notifications.AuthenticationRequestCreated(authnRequest, idp, relayData);
 

--- a/Tests/Tests.Shared/IdentityProviderTests.cs
+++ b/Tests/Tests.Shared/IdentityProviderTests.cs
@@ -48,8 +48,6 @@ namespace Sustainsys.Saml2.Tests
         {
             // %41 is A, which doesn't need to be encoded. Ensure it is kept in original format.
             string idpUri = "http://idp.example.com/x=%41";
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
 
             var subject = new IdentityProvider(
                 new EntityId(idpUri),
@@ -58,7 +56,7 @@ namespace Sustainsys.Saml2.Tests
                 SingleSignOnServiceUrl = new Uri(idpUri)
             };
 
-            var r = subject.CreateAuthenticateRequest(StubFactory.CreateSaml2Urls(), httpRequest);
+            var r = subject.CreateAuthenticateRequest(StubFactory.CreateSaml2Urls());
 
             r.ToXElement().Attribute("Destination").Should().NotBeNull()
                 .And.Subject.Value.Should().Be(idpUri);
@@ -70,11 +68,9 @@ namespace Sustainsys.Saml2.Tests
             var options = Options.FromConfiguration;
 
             var idp = options.IdentityProviders.Default;
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
 
             var urls = StubFactory.CreateSaml2Urls();
-            var subject = idp.CreateAuthenticateRequest(urls, httpRequest);
+            var subject = idp.CreateAuthenticateRequest(urls);
 
             var expected = new Saml2AuthenticationRequest()
             {
@@ -103,11 +99,9 @@ namespace Sustainsys.Saml2.Tests
             var options = StubFactory.CreateOptionsPublicOrigin(origin);
 
             var idp = options.IdentityProviders.Default;
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
 
             var urls = StubFactory.CreateSaml2UrlsPublicOrigin(origin);
-            var subject = idp.CreateAuthenticateRequest(urls, httpRequest);
+            var subject = idp.CreateAuthenticateRequest(urls);
 
             var expected = new Saml2AuthenticationRequest()
             {
@@ -129,12 +123,10 @@ namespace Sustainsys.Saml2.Tests
             var options = StubFactory.CreateOptions();
             var idp = options.IdentityProviders.Default;
             var urls = StubFactory.CreateSaml2Urls();
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
 
             options.SPOptions.AttributeConsumingServices.Clear();
 
-            var subject = idp.CreateAuthenticateRequest(urls, httpRequest);
+            var subject = idp.CreateAuthenticateRequest(urls);
 
             var expected = new Saml2AuthenticationRequest()
             {
@@ -154,10 +146,8 @@ namespace Sustainsys.Saml2.Tests
         public void IdentityProvider_CreateAuthenticateRequest_NullcheckSaml2Urls()
         {
             var idp = Options.FromConfiguration.IdentityProviders.Default;
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
 
-            Action a = () => idp.CreateAuthenticateRequest(null, httpRequest);
+            Action a = () => idp.CreateAuthenticateRequest(null);
 
             a.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("saml2Urls");
         }
@@ -175,10 +165,8 @@ namespace Sustainsys.Saml2.Tests
 
             var idp = options.IdentityProviders.Default;
             var urls = StubFactory.CreateSaml2Urls();
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
 
-            var subject = idp.CreateAuthenticateRequest(urls, httpRequest);
+            var subject = idp.CreateAuthenticateRequest(urls);
 
             subject.SigningCertificate.Thumbprint.Should().Be(SignedXmlHelper.TestCert.Thumbprint);
         }
@@ -191,10 +179,8 @@ namespace Sustainsys.Saml2.Tests
 
             var subject = options.IdentityProviders[new EntityId("https://idp2.example.com")];
             var urls = StubFactory.CreateSaml2Urls();
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
 
-            var actual = subject.CreateAuthenticateRequest(urls, httpRequest).SigningCertificate;
+            var actual = subject.CreateAuthenticateRequest(urls).SigningCertificate;
 
             (actual?.Thumbprint).Should().Be(SignedXmlHelper.TestCert2.Thumbprint);
         }
@@ -215,10 +201,8 @@ namespace Sustainsys.Saml2.Tests
                 WantAuthnRequestsSigned = true
             };
             var urls = StubFactory.CreateSaml2Urls();
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
 
-            var actual = subject.CreateAuthenticateRequest(urls, httpRequest).SigningCertificate;
+            var actual = subject.CreateAuthenticateRequest(urls).SigningCertificate;
 
             actual.Should().BeNull();
         }
@@ -232,10 +216,8 @@ namespace Sustainsys.Saml2.Tests
 
             var idp = options.IdentityProviders.Default;
             var urls = StubFactory.CreateSaml2Urls();
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
 
-            idp.Invoking(i => i.CreateAuthenticateRequest(urls, httpRequest))
+            idp.Invoking(i => i.CreateAuthenticateRequest(urls))
                 .Should().Throw<ConfigurationErrorsException>()
                 .WithMessage($"Idp \"https://idp.example.com\" is configured for signed AuthenticateRequests*");
         }
@@ -781,8 +763,6 @@ namespace Sustainsys.Saml2.Tests
         public void IdentityProvider_MetadataLoadedConfiguredFromCode()
         {
             var spOptions = StubFactory.CreateSPOptions();
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
 
             spOptions.ServiceCertificates.Add(new ServiceCertificate()
             {
@@ -807,7 +787,7 @@ namespace Sustainsys.Saml2.Tests
             subject.SingleSignOnServiceUrl.Should().Be("http://wrong.entityid.example.com/acs");
             subject.WantAuthnRequestsSigned.Should().Be(true, "WantAuthnRequestsSigned should have been loaded from metadata");
 
-            Action a = () => subject.CreateAuthenticateRequest(StubFactory.CreateSaml2Urls(), httpRequest);
+            Action a = () => subject.CreateAuthenticateRequest(StubFactory.CreateSaml2Urls());
             a.Should().NotThrow();
         }
 

--- a/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
@@ -24,6 +24,7 @@ using SigningCredentials = Microsoft.IdentityModel.Tokens.SigningCredentials;
 using X509SecurityKey = Microsoft.IdentityModel.Tokens.X509SecurityKey;
 using System.Collections.Generic;
 using Microsoft.IdentityModel.Logging;
+using Sustainsys.Saml2.WebSso;
 
 namespace Sustainsys.Saml2.Tests.Saml2P
 {
@@ -1628,8 +1629,10 @@ namespace Sustainsys.Saml2.Tests.Saml2P
         public void Saml2Response_GetClaims_MissingInResponseTo_IfAllowed()
         {
             var idp = Options.FromConfiguration.IdentityProviders.Default;
+            var httpRequest = new HttpRequestData("GET",
+                new Uri("http://sp.example.com"));
 
-            var request = idp.CreateAuthenticateRequest(StubFactory.CreateSaml2Urls());
+            var request = idp.CreateAuthenticateRequest(StubFactory.CreateSaml2Urls(), httpRequest);
 
             var responseXML =
             @"<?xml version=""1.0"" encoding=""UTF-8""?>

--- a/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
@@ -1629,10 +1629,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
         public void Saml2Response_GetClaims_MissingInResponseTo_IfAllowed()
         {
             var idp = Options.FromConfiguration.IdentityProviders.Default;
-            var httpRequest = new HttpRequestData("GET",
-                new Uri("http://sp.example.com"));
-
-            var request = idp.CreateAuthenticateRequest(StubFactory.CreateSaml2Urls(), httpRequest);
+            var request = idp.CreateAuthenticateRequest(StubFactory.CreateSaml2Urls());
 
             var responseXML =
             @"<?xml version=""1.0"" encoding=""UTF-8""?>


### PR DESCRIPTION
I have added support for the IsPassive flag. It is read from the API call and added to the SAML request. The parsing of the SAML "nopassive" flag that can be a response from the IDP on the passive logon request was already implemented.