### PR TITLE
Set the cookie "Secure" flag iff the ACS post back URL is HTTPS

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/CommandResultExtensions.cs
+++ b/Sustainsys.Saml2.AspNetCore2/CommandResultExtensions.cs
@@ -35,6 +35,7 @@ namespace Sustainsys.Saml2.AspNetCore2
                     new CookieOptions()
                     {
                         HttpOnly = true,
+                        Secure = commandResult.SetCookieSecureFlag,
                         // We are expecting a different site to POST back to us,
                         // so the ASP.Net Core default of Lax is not appropriate in this case
                         SameSite = SameSiteMode.None,

--- a/Sustainsys.Saml2.HttpModule/CommandResultHttpExtensionsShared.cs
+++ b/Sustainsys.Saml2.HttpModule/CommandResultHttpExtensionsShared.cs
@@ -42,7 +42,8 @@ namespace Sustainsys.Saml2.HttpModule
                     commandResult.SetCookieName,
                     protectedData)
                 {
-                    HttpOnly = true
+                    HttpOnly = true,
+                    Secure = commandResult.SetCookieSecureFlag,
                 });
             }
 

--- a/Sustainsys.Saml2.Owin/CommandResultExtensions.cs
+++ b/Sustainsys.Saml2.Owin/CommandResultExtensions.cs
@@ -71,6 +71,7 @@ namespace Sustainsys.Saml2.Owin
                     new CookieOptions()
                     {
                         HttpOnly = true,
+                        Secure = commandResult.SetCookieSecureFlag,
                     });
             }
 

--- a/Sustainsys.Saml2/WebSSO/CommandResult.cs
+++ b/Sustainsys.Saml2/WebSSO/CommandResult.cs
@@ -68,6 +68,11 @@ namespace Sustainsys.Saml2.WebSso
         public string SetCookieName { get; set; }
 
         /// <summary>
+        /// Value of the "Secure" flag for the cookie (relevant if <see cref="SetCookieName"/> != null).
+        /// </summary>
+        public bool SetCookieSecureFlag { get; set; }
+
+        /// <summary>
         /// SAML RelayState value
         /// </summary>
         public string RelayState { get; set; }

--- a/Sustainsys.Saml2/WebSSO/SignInCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/SignInCommand.cs
@@ -157,6 +157,8 @@ namespace Sustainsys.Saml2.WebSso
 
             commandResult.RequestState = new StoredRequestState(
                 idp.EntityId, returnUrl, authnRequest.Id, relayData);
+
+            commandResult.SetCookieSecureFlag = string.Equals(urls.AssertionConsumerServiceUrl.Scheme, "https", StringComparison.OrdinalIgnoreCase);
             commandResult.SetCookieName = StoredRequestState.CookieNameBase + authnRequest.RelayState;
 
             options.Notifications.SignInCommandResultCreated(commandResult, relayData);

--- a/Tests/AspNetCore2.Tests/CommandResultExtensionsTests.cs
+++ b/Tests/AspNetCore2.Tests/CommandResultExtensionsTests.cs
@@ -41,6 +41,7 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
                 HttpStatusCode = System.Net.HttpStatusCode.Redirect,
                 Location = new Uri(redirectLocation),
                 SetCookieName = "Saml2.123",
+                SetCookieSecureFlag = true,
                 RelayState = "123",
                 RequestState = state,
                 ContentType = "application/json",
@@ -78,7 +79,8 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
             context.Response.Headers["Location"].SingleOrDefault()
                 .Should().Be(redirectLocation, "location header should be set");
             context.Response.Cookies.Received().Append(
-                "Saml2.123", expectedCookieData, Arg.Is<CookieOptions>(co => co.HttpOnly && co.SameSite == SameSiteMode.None));
+                "Saml2.123", expectedCookieData, Arg.Is<CookieOptions>(
+                    co => co.HttpOnly && co.Secure && co.SameSite == SameSiteMode.None));
 
             context.Response.Cookies.Received().Delete("Clear-Cookie");
 

--- a/Tests/HttpModule.Tests/CommandResultHttpTests.cs
+++ b/Tests/HttpModule.Tests/CommandResultHttpTests.cs
@@ -52,6 +52,7 @@ namespace Sustainsys.Saml2.HttpModule.Tests
             new CommandResult()
             {
                 SetCookieName = "CookieName",
+                SetCookieSecureFlag = true,
                 RequestState = new StoredRequestState(
                     new EntityId("http://idp.example.com"),
                     null,
@@ -64,7 +65,8 @@ namespace Sustainsys.Saml2.HttpModule.Tests
                 c.Name == "CookieName"
                 && c.Value.All(ch => ch != '/' && ch != '+' && ch != '=')
                 && new StoredRequestState(DecryptCookieData(c.Value)).Idp.Id == "http://idp.example.com"
-                && c.HttpOnly == true));
+                && c.HttpOnly == true
+                && c.Secure == true));
         }
 
         private byte[] DecryptCookieData(string data)

--- a/Tests/Owin.Tests/CommandResultExtensionsTests.cs
+++ b/Tests/Owin.Tests/CommandResultExtensionsTests.cs
@@ -62,7 +62,8 @@ namespace Sustainsys.Saml2.Owin.Tests
                     new Uri("http://sp.example.com/loggedout"),
                     new Saml2Id("id123"),
                     null),
-                SetCookieName = "CookieName"
+                SetCookieName = "CookieName",
+                SetCookieSecureFlag = true,
             };
 
             var context = OwinTestHelpers.CreateOwinContext();
@@ -75,7 +76,7 @@ namespace Sustainsys.Saml2.Owin.Tests
             var protectedData = HttpRequestData.ConvertBinaryData(
                 StubDataProtector.Protect(cr.GetSerializedRequestState()));
 
-            var expected = $"CookieName={protectedData}; path=/; HttpOnly";
+            var expected = $"CookieName={protectedData}; path=/; secure; HttpOnly";
 
             setCookieHeader.Should().Be(expected);
         }

--- a/Tests/Tests.Shared/WebSSO/SignInCommandTests.cs
+++ b/Tests/Tests.Shared/WebSSO/SignInCommandTests.cs
@@ -412,5 +412,41 @@ namespace Sustainsys.Saml2.Tests.WebSso
 
             a.Should().NotThrow();
         }
+
+        [TestMethod]
+        public void SignInCommand_WithHttpUrl_DoesNotSetSecureCookieFlag()
+        {
+            var options = StubFactory.CreateOptions();
+            var httpRequest = new HttpRequestData("GET", new Uri("http://localhost"));
+
+            var actual = SignInCommand.Run(options.IdentityProviders.Default.EntityId, null, httpRequest, options, null);
+
+            actual.SetCookieName.Should().StartWith(StoredRequestState.CookieNameBase);
+            actual.SetCookieSecureFlag.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void SignInCommand_WithHttpsUrl_SetsSecureCookieFlag()
+        {
+            var options = StubFactory.CreateOptions();
+            var httpRequest = new HttpRequestData("GET", new Uri("https://localhost"));
+
+            var actual = SignInCommand.Run(options.IdentityProviders.Default.EntityId, null, httpRequest, options, null);
+
+            actual.SetCookieName.Should().StartWith(StoredRequestState.CookieNameBase);
+            actual.SetCookieSecureFlag.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void SignInCommand_WithHttpsPublicOrigin_SetsSecureCookieFlag()
+        {
+            var options = StubFactory.CreateOptionsPublicOrigin(new Uri("https://my.public.origin:8443"));
+            var httpRequest = new HttpRequestData("GET", new Uri("http://localhost"));
+
+            var actual = SignInCommand.Run(options.IdentityProviders.Default.EntityId, null, httpRequest, options, null);
+
+            actual.SetCookieName.Should().StartWith(StoredRequestState.CookieNameBase);
+            actual.SetCookieSecureFlag.Should().BeTrue();
+        }
     }
 }


### PR DESCRIPTION
Partially fixes #1091 (for the ASP.NET _Core_ version).

This allows to comply with the new (Chrome >= 80) "Reject insecure SameSite=None cookies" rule (which otherwise would drop the `SignInCommand` correlation cookie).

Manually tested: 
 * ASP.NET Core: Chrome 80 (Dev Channel) with enabled "SameSite by default cookies" and "Cookies without SameSite must be secure" flags in chrome://flags/