### PR TITLE
Skip processing form data for POSTs without a valid content-type

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/HttpRequestExtensions.cs
+++ b/Sustainsys.Saml2.AspNetCore2/HttpRequestExtensions.cs
@@ -25,7 +25,7 @@ namespace Sustainsys.Saml2.AspNetCore2
             var pathBase = httpContext.Request.PathBase.Value;
             pathBase = string.IsNullOrEmpty(pathBase) ? "/" : pathBase;
             IEnumerable<KeyValuePair<string, IEnumerable<string>>> formData = null;
-            if (httpContext.Request.Method == "POST")
+            if (httpContext.Request.Method == "POST" && httpContext.Request.HasFormContentType)
             {
                 formData = request.Form.Select(
                     f => new KeyValuePair<string, IEnumerable<string>>(f.Key, f.Value));

--- a/Tests/AspNetCore2.Tests/HttpContextExtensionsTests.cs
+++ b/Tests/AspNetCore2.Tests/HttpContextExtensionsTests.cs
@@ -48,6 +48,19 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
         }
 
         [TestMethod]
+        public void HttpContextExtensions_ToHttpRequestData_InvalidPost()
+        {
+            var context = TestHelpers.CreateHttpContext();
+
+            context.Request.HasFormContentType.Returns(false);
+            context.Request.Form.Returns(i => { throw new InvalidOperationException(); });
+
+            context.ToHttpRequestData(StubDataProtector.Unprotect);
+
+            // No exception = pass
+        }
+
+        [TestMethod]
         public void HttpContextExtensions_ToHttpRequestData_ApplicationNotInRoot()
         {
             var context = TestHelpers.CreateHttpContext();

--- a/Tests/AspNetCore2.Tests/TestHelpers.cs
+++ b/Tests/AspNetCore2.Tests/TestHelpers.cs
@@ -53,6 +53,7 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
         {
             var context = Substitute.For<HttpContext>();
 
+            context.Request.HasFormContentType.Returns(true);
             context.Request.Form.Returns(new FormValues());
             context.Request.Method = "POST";
             context.Request.ContentType = "application/x-www-form-urlencoded";


### PR DESCRIPTION
This avoids an exception.