### PR TITLE
feat: Add optional compatibility option to support non-complaint IDPs that do not sign their LogOut responses.

### DIFF
--- a/Sustainsys.Saml2/Configuration/Compatibility.cs
+++ b/Sustainsys.Saml2/Configuration/Compatibility.cs
@@ -80,5 +80,13 @@ namespace Sustainsys.Saml2.Configuration
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout")]
         public bool EnableLogoutOverPost { get; set; }
+
+        /// <summary>
+        /// SAML2 Specs says in section 4.4.4.2:
+        /// "... The responder MUST authenticate itself to the requester and ensure message integrity, either by signing the message or using a binding-specific mechanism."
+        /// 
+        /// Unfortunately not all IDP seem to follow the specification. Disables requirement for a signed LogoutResponse.
+        /// </summary>
+        public bool AcceptUnsignedLogoutResponses { get; set; }
     }
 }

--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -83,7 +83,11 @@ namespace Sustainsys.Saml2.WebSso
                 var unbindResult = binding.Unbind(request, options);
                 options.Notifications.MessageUnbound(unbindResult);
 
-                VerifyMessageIsSigned(unbindResult, options);
+                if (!options.SPOptions.Compatibility.AcceptUnsignedLogoutResponses)
+                {
+                    VerifyMessageIsSigned(unbindResult, options);
+                }
+
                 switch (unbindResult.Data.LocalName)
                 {
                     case "LogoutRequest":


### PR DESCRIPTION
We got hit by issue https://github.com/Sustainsys/Saml2/issues/446, after our IDP began to returning unsigned LogOut responses. I have added a compatibility switch to support this specification violating behaviour, while we work with the IDP provider to get them in compliance with the spec.