### PR TITLE
Add subject to AuthnRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/kf9r7lh4mh28rg2d?branch=master&svg=true&passingText=master%20-%20OK&failingText=master%20-%20Failed!&pendingText=master%20-%20Pending...)](https://ci.appveyor.com/project/Sustainsys/Saml2)<!-- Skip for now, disabled due to build server problems [![Coverage status](https://coveralls.io/repos/github/Sustainsys/Saml2/badge.svg?branch=master)](https://coveralls.io/github/Sustainsys/Saml2?branch=master) -->
-[![Docs status](https://readthedocs.org/projects/saml2/badge/?version=latest)](https://saml2.sustainsys.com)
 [![Join the chat at https://gitter.im/Susatinsys/Saml2](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Sustainsys/Saml2)
 Sustainsys.Saml2
 =============

--- a/Sustainsys.Saml2.AspNetCore2/PostConfigureSaml2Options.cs
+++ b/Sustainsys.Saml2.AspNetCore2/PostConfigureSaml2Options.cs
@@ -11,7 +11,11 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 
 namespace Sustainsys.Saml2.AspNetCore2
 {
-    class PostConfigureSaml2Options : IPostConfigureOptions<Saml2Options>
+    /// <summary>
+    /// Post configure service to set default values in configuration if
+    /// the startup didn't set them.
+    /// </summary>
+    public class PostConfigureSaml2Options : IPostConfigureOptions<Saml2Options>
     {
         private ILoggerFactory loggerFactory;
         private IOptions<AuthenticationOptions> authOptions;
@@ -29,6 +33,11 @@ namespace Sustainsys.Saml2.AspNetCore2
             this.authOptions = authOptions;
         }
 
+        /// <summary>
+        /// Add defaults to configuration.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="options"></param>
         public void PostConfigure(string name, Saml2Options options)
         {
             if(options == null)

--- a/Sustainsys.Saml2.sln
+++ b/Sustainsys.Saml2.sln
@@ -101,6 +101,7 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Tests\Tests.Shared\Tests.Shared.projitems*{82f84e61-1292-47cf-b0dc-59f26ec56c32}*SharedItemsImports = 13
 		Tests\Tests.Shared\Tests.Shared.projitems*{c5c43d57-3a9c-4edf-97af-ee55a950284c}*SharedItemsImports = 4
+		Tests\Tests.Shared\Tests.Shared.projitems*{ff774b2e-51d4-4c64-ba0e-c061683a9b93}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Sustainsys.Saml2/Configuration/Compatibility.cs
+++ b/Sustainsys.Saml2/Configuration/Compatibility.cs
@@ -80,5 +80,13 @@ namespace Sustainsys.Saml2.Configuration
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout")]
         public bool EnableLogoutOverPost { get; set; }
+
+        /// <summary>
+        /// SAML2 Specs says in section 4.4.4.2:
+        /// "... The responder MUST authenticate itself to the requester and ensure message integrity, either by signing the message or using a binding-specific mechanism."
+        /// 
+        /// Unfortunately not all IDP seem to follow the specification. Disables requirement for a signed LogoutResponse.
+        /// </summary>
+        public bool AcceptUnsignedLogoutResponses { get; set; }
     }
 }

--- a/Sustainsys.Saml2/SAML2P/Saml2PSecurityTokenHandler.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2PSecurityTokenHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Tokens.Saml2;
 using Sustainsys.Saml2.Configuration;
+using Sustainsys.Saml2.Exceptions;
 using Sustainsys.Saml2.Internal;
 using Sustainsys.Saml2.Tokens;
 using System;
@@ -97,6 +98,22 @@ namespace Sustainsys.Saml2.Saml2P
 			}
 
 			return new ClaimsPrincipal(identity);
+		}
+		private static readonly Uri bearerUri = new Uri("urn:oasis:names:tc:SAML:2.0:cm:bearer");
+
+		protected override void ValidateSubject(Saml2SecurityToken samlToken, TokenValidationParameters validationParameters)
+		{
+			base.ValidateSubject(samlToken, validationParameters);
+
+			if(!samlToken.Assertion.Subject.SubjectConfirmations.Any())
+			{
+				throw new Saml2ResponseFailedValidationException("No subject confirmation method found.");
+			}
+
+			if(!samlToken.Assertion.Subject.SubjectConfirmations.Any(sc => sc.Method == bearerUri))
+			{
+				throw new Saml2ResponseFailedValidationException("Only assertions with subject confirmation method \"bearer\" are supported.");
+			}
 		}
 	}
 }

--- a/Sustainsys.Saml2/Saml2SubjectExtensions.cs
+++ b/Sustainsys.Saml2/Saml2SubjectExtensions.cs
@@ -13,8 +13,10 @@ namespace Sustainsys.Saml2
         /// Writes out the subject as an XElement.
         /// </summary>
         /// <param name="subject">The subject to create xml for.</param>
+        /// <param name="addBearer">Indicates if the "Bearer" type should be added.</param>
         /// <returns>XElement</returns>
-        public static XElement ToXElement(this Saml2Subject subject)
+        /// <remarks>addBearer is a workaround to skip it in an AuthnRequest.</remarks>
+        public static XElement ToXElement(this Saml2Subject subject, bool addBearer = true)
         {
             if (subject == null)
             {
@@ -29,7 +31,7 @@ namespace Sustainsys.Saml2
                 element.Add(subjectConfirmation.ToXElement());
             }
 
-            if (subject.SubjectConfirmations.Count == 0)
+            if (addBearer && (subject.SubjectConfirmations.Count == 0))
             {
                 // Although SubjectConfirmation is optional in the SAML core spec, it is
                 // mandatory in the Web Browser SSO Profile and must have a value of bearer.

--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -83,13 +83,17 @@ namespace Sustainsys.Saml2.WebSso
                 var unbindResult = binding.Unbind(request, options);
                 options.Notifications.MessageUnbound(unbindResult);
 
-                VerifyMessageIsSigned(unbindResult, options);
                 switch (unbindResult.Data.LocalName)
                 {
                     case "LogoutRequest":
+                        VerifyMessageIsSigned(unbindResult, options);
                         commandResult = HandleRequest(unbindResult, request, options);
                         break;
                     case "LogoutResponse":
+                        if (!options.SPOptions.Compatibility.AcceptUnsignedLogoutResponses)
+                        {
+                            VerifyMessageIsSigned(unbindResult, options);
+                        }
                         var storedRequestState = options.Notifications.GetLogoutResponseState(request);
                         var urls = new Saml2Urls(request, options);
                         commandResult = HandleResponse(unbindResult, storedRequestState, options, returnUrl, urls);

--- a/Tests/Tests.Shared/WebSSO/LogoutCommandTests.cs
+++ b/Tests/Tests.Shared/WebSSO/LogoutCommandTests.cs
@@ -396,6 +396,63 @@ namespace Sustainsys.Saml2.Tests.WebSso
         }
 
         [TestMethod]
+        public void LogoutCommand_Run_RejectsUnsignedLogoutResponse()
+        {
+            var relayState = "MyRelayState";
+            var response = new Saml2LogoutResponse(Saml2StatusCode.Success)
+            {
+                DestinationUrl = new Uri("http://sp.example.com/path/Saml2/logout"),
+                Issuer = new EntityId("https://idp.example.com"),
+                InResponseTo = new Saml2Id(),
+                RelayState = relayState
+            };
+
+            var bindResult = Saml2Binding.Get(Saml2BindingType.HttpRedirect)
+                .Bind(response);
+
+            var request = new HttpRequestData("GET",
+                bindResult.Location,
+                "http://sp-internal.example.com/path/Saml2",
+                null,
+                new StoredRequestState(null, new Uri("http://loggedout.example.com"), null, null));
+
+            var options = StubFactory.CreateOptions();
+
+            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+                .Invoking(c => c.Run(request, options))
+                .Should().Throw<UnsuccessfulSamlOperationException>();
+        }
+
+        [TestMethod]
+        public void LogoutCommand_Run_AcceptsUnsignedLogoutResponseIfCompatFlagSet()
+        {
+            var relayState = "MyRelayState";
+            var response = new Saml2LogoutResponse(Saml2StatusCode.Success)
+            {
+                DestinationUrl = new Uri("http://sp.example.com/path/Saml2/logout"),
+                Issuer = new EntityId("https://idp.example.com"),
+                InResponseTo = new Saml2Id(),
+                RelayState = relayState
+            };
+
+            var bindResult = Saml2Binding.Get(Saml2BindingType.HttpRedirect)
+                .Bind(response);
+
+            var request = new HttpRequestData("GET",
+                bindResult.Location,
+                "http://sp-internal.example.com/path/Saml2",
+                null,
+                new StoredRequestState(null, new Uri("http://loggedout.example.com"), null, null));
+
+            var options = StubFactory.CreateOptions();
+            options.SPOptions.Compatibility.AcceptUnsignedLogoutResponses = true;
+
+            // Should not throw.
+            CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+                .Run(request, options);
+        }
+
+        [TestMethod]
         public void LogoutCommand_Run_HandlesLogoutResponse_InPost()
         {
             var relayState = "TestState";
@@ -741,7 +798,6 @@ namespace Sustainsys.Saml2.Tests.WebSso
                 .WithMessage("Received a LogoutRequest from https://idp.example.com that cannot be processed because it is not signed.");
         }
 
-
         [TestMethod]
         public void LogoutCommand_Run_ThrowsOnLogoutResponseStatusNonSuccess()
         {
@@ -969,7 +1025,7 @@ namespace Sustainsys.Saml2.Tests.WebSso
                 MessageName = "SAMLRequest",
                 SigningCertificate = SignedXmlHelper.TestCert,
                 DestinationUrl = new Uri("http://localhost"),
-                XmlData = "<Xml />"
+                XmlData = "<samlp:LogoutRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\"/>"
             };
 
             var url = Saml2Binding.Get(Saml2BindingType.HttpRedirect)

--- a/VersionInfo.cs
+++ b/VersionInfo.cs
@@ -11,6 +11,6 @@ using System.Reflection;
 //      Patch Number
 //
 
-[assembly: AssemblyVersion("2.6.0")]
-[assembly: AssemblyFileVersion("2.6.0")]
-[assembly: AssemblyInformationalVersion("2.6.0")]
+[assembly: AssemblyVersion("2.7.0")]
+[assembly: AssemblyFileVersion("2.7.0")]
+[assembly: AssemblyInformationalVersion("2.7.0")]

--- a/nuget/MakePackage.ps1
+++ b/nuget/MakePackage.ps1
@@ -9,14 +9,6 @@ if ("$clean" -eq "")
   exit
 }
 
-$master = $status | select-string "On branch master"
-
-if ("$master" -eq "")
-{
-  echo "Releases are only allowed from the master branch."
-  exit
-}
-
 pushd ..
 if (Test-Path "Sustainsys.Saml2\bin\Release")
 {

--- a/nuget/ReleaseNotes.txt
+++ b/nuget/ReleaseNotes.txt
@@ -1,3 +1,7 @@
+Version 2.7.0
+* Security Fix: Ensure received token is a bearer token.
+* Compatibility flag to allow unsigned logout responses
+
 Version 2.6.0
 * Xml Created Notifications
 
@@ -6,11 +10,5 @@ Version 2.5.0
 * Configuration of TokenValidationParameters
 * Use CookieManager in Asp.Net Core and Owin
 * Bug fixes to Artifact binding, AuthnRequest, Owin Logout
-
-Version 2.4.0
-* SameSite cookie update for Chrome 80
-* TokenValidationParametersCreated notification
-* Bug Fix: Handle query string with =
-* Improved error messages
 
 See GitHub milestone issue list for details.


### PR DESCRIPTION
It adds a Subject property to the Saml2AuthenticationRequest (with an XML writer and parser). And a bit of an ugly work around to make it work. It adds a bool parameter to the Saml2SubjectExtension.ToXElement(). The AuthnRequest should not have the “Bearer”. Although ugly, it does not break existing code this way. Of course any other solution is fine for us.

It is not used every day . I do know two applications.

- I am working on a project [MFA on ADFS](https://github.com/SURFnet/ADFS-MFA-SAML2.0-Extension) It is an implementation of Microsoft.IdentityServer.Web.Authentication.External.IAuthenticationAdapter. The MFA interface of an ADFS server. It uses Sustainssys.Saml2 to create a SAML2 AuthnRequest to a server which verifies the “Second Factor”. It uses Sustainsys.Saml2.dll (v2.7) to create the request and parse the response.

- I have seen another use of Subject in the AuthnRequest. If an entity wants to know if a particular Subject is already logged on to an IdP, then they send an AuthnRequest with IsPassive=true and a Subject. The IdP will reply if they are already signed in.