### PR TITLE
Adding fips compliance changes to Sustainsys library

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ There are three active branches in the repo
 
 ## Documentation
 Complete documentation is available at [our documentation site](https://saml2.sustainsys.com).
+
+##Fips Compliance
+The default encryption algorithm used is now AesCryptoServiceProvider, this is use in order to be fips compliant.
+If Key Algorithm is AES256 or TripleDES then the decryption will occur with an overrided GetDecryptionKey method from .Net
+The orverriden method should look at the encrpted key and use an AesCryptoServiceProvider or TripleDESCryptoProvider instance instead of using the base class CreateFromName method.
+AES256 or TripleDES were selected as the only 2 Fips compliance algorithms to be included for this validation following the following FIPS document.
+ https://csrc.nist.gov/csrc/media/publications/fips/140/2/final/documents/fips1402annexa.pdf
+If your Key algorithm is different from AES256 or TripleDES it simply will use the GetDecryptionKey base implementation for decryption.

--- a/Sustainsys.Saml2.sln
+++ b/Sustainsys.Saml2.sln
@@ -80,7 +80,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "config-elements", "config-e
 		docs\config-elements\sustainsys-saml2.rst = docs\config-elements\sustainsys-saml2.rst
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sustainsys.Saml2.Metadata", "Sustainsys.Saml2.Metadata\Sustainsys.Saml2.Metadata.csproj", "{84CB2BF8-5EB7-4F82-951B-2ECA45CD0BE2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sustainsys.Saml2.Metadata", "Sustainsys.Saml2.Metadata\Sustainsys.Saml2.Metadata.csproj", "{84CB2BF8-5EB7-4F82-951B-2ECA45CD0BE2}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -144,6 +144,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{8EE1C45E-A81F-4D3F-A645-4C20528E327F} = {09639770-8C2B-4D30-BBFC-4F6DD1A92C89}
 		{CF1E517E-B2FE-48E1-8BB9-4D9981695C47} = {F3C8CC66-4CE9-4683-BC31-B89AF47A5897}
 		{8EB3820A-4DB4-4875-A155-6C3D7458983E} = {09639770-8C2B-4D30-BBFC-4F6DD1A92C89}
 		{20359A9A-6435-4264-8B36-22CD76731432} = {F3C8CC66-4CE9-4683-BC31-B89AF47A5897}

--- a/Sustainsys.Saml2/Internal/CryptographyExtensions.cs
+++ b/Sustainsys.Saml2/Internal/CryptographyExtensions.cs
@@ -80,11 +80,10 @@ namespace Sustainsys.Saml2.Internal
 
             var encryptedXml = new EncryptedXml();
             byte[] encryptedElement;
-            using (var symmetricAlgorithm = new RijndaelManaged())
-            {
+
+            using (var symmetricAlgorithm = new AesCryptoServiceProvider()) {
                 X509SecurityKey x509SecurityKey = encryptingCredentials.Key as X509SecurityKey;
-                if (x509SecurityKey == null)
-                {
+                if (x509SecurityKey == null) {
                     throw new CryptographicException(
                         "The encrypting credentials have an unknown key of type {encryptingCredentials.Key.GetType()}");
                 }
@@ -119,8 +118,8 @@ namespace Sustainsys.Saml2.Internal
 
             var encryptedXml = new EncryptedXml();
             byte[] encryptedElement;
-            using (var symmetricAlgorithm = new RijndaelManaged())
-            {
+
+            using (var symmetricAlgorithm = new AesCryptoServiceProvider()) {
                 symmetricAlgorithm.KeySize = 256;
                 encryptedKey.CipherData = new CipherData(EncryptedXml.EncryptKey(symmetricAlgorithm.Key, (RSA)certificate.PublicKey.Key, useOaep));
                 encryptedElement = encryptedXml.EncryptData(elementToEncrypt, symmetricAlgorithm, false);
@@ -207,6 +206,17 @@ namespace Sustainsys.Saml2.Internal
                 throw new CryptographicException($"Unknown crypto algorithm '{name}'");
             }
             return Activator.CreateInstance(type, args);
+        }
+
+        internal static SymmetricAlgorithm SymmetricFactory(string type) {
+            switch (type) {
+                case EncryptedXml.XmlEncAES256Url:
+                    return new AesCryptoServiceProvider();
+                case EncryptedXml.XmlEncTripleDESUrl:
+                    return new TripleDESCryptoServiceProvider();
+                default:
+                    return new AesCryptoServiceProvider();
+            }
         }
     }
 }

--- a/Sustainsys.Saml2/Internal/RSAEncryptedXml.cs
+++ b/Sustainsys.Saml2/Internal/RSAEncryptedXml.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using Sustainsys.Saml2.Configuration;
+using System;
+using System.Collections;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Xml;
 using System.Xml;
@@ -8,16 +11,16 @@ namespace Sustainsys.Saml2.Internal
     internal class RSAEncryptedXml : EncryptedXml
     {
         private readonly RSA privateKey;
+        private XmlDocument document;
+        private string symmetricAlgorithmUri;
 
         public RSAEncryptedXml(XmlDocument document, RSA rsaKey)
-            : base(document)
-        {
+            : base(document) {
+            this.document = document;
             privateKey = rsaKey;
         }
 
         // Try to decrypt the EncryptedKey by the given key
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CipherReference"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "CipherData")]
-        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute]
         public override byte[] DecryptEncryptedKey(EncryptedKey encryptedKey)
         {
             if (encryptedKey == null)
@@ -25,7 +28,7 @@ namespace Sustainsys.Saml2.Internal
                 throw new ArgumentNullException(nameof(encryptedKey));
             }
 
-            if (encryptedKey.CipherData.CipherValue == null)
+            if (encryptedKey.CipherData.CipherValue == null || encryptedKey.CipherData.CipherValue.Count() == 0)
             {
                 throw new NotImplementedException("Unable to decode CipherData of type \"CipherReference\".");
             }
@@ -41,5 +44,111 @@ namespace Sustainsys.Saml2.Internal
 
             return DecryptKey(encryptedKey.CipherData.CipherValue, privateKey, useOaep);
         }
+
+        // Override EncryptedXml.GetDecryptionKey to avoid calling into CryptoConfig.CreateFromName
+        // When detect AES, we need to return AesCryptoServiceProvider (FIPS certified) instead of AesManaged (FIPS obsolated)
+        public override SymmetricAlgorithm GetDecryptionKey(EncryptedData encryptedData, string symmetricAlgorithmUri) {
+            if (encryptedData == null) {
+                throw new ArgumentNullException("No Encrypted Data Provided");
+            }
+            // If the Uri is not provided by the application, try to get it from the EncryptionMethod
+            if (symmetricAlgorithmUri == null) {
+                if (encryptedData.EncryptionMethod == null) {
+                    throw new CryptographicException("No Cryptograpy algorithm provided in encryption method");
+                }
+                this.symmetricAlgorithmUri = encryptedData.EncryptionMethod.KeyAlgorithm;
+			} else {
+                this.symmetricAlgorithmUri = symmetricAlgorithmUri;
+            }
+            // If AES is used then assume FIPS is required
+            if (IsSymmetricKeyRequiresFipsCompliantImplementation(this.symmetricAlgorithmUri)) {
+                if (encryptedData.KeyInfo == null) {
+                    return null;
+                }
+
+                EncryptedKey ek = GetEncryptedKeyfromKeyInfoClause(encryptedData);
+                // if we have an EncryptedKey, decrypt to get the symmetric key
+                if (ek != null) {
+                    // now process the EncryptedKey, loop recursively           
+                    byte[] key = DecryptEncryptedKey(ek);
+                    if (key == null) {
+                        throw new CryptographicException("No Decryption Key found");
+                    }
+                    // encryptedData.EncryptionMethod.KeyAlgorithm shound be any of the 2 algorithms;
+                    SymmetricAlgorithm symAlg = CryptographyExtensions.SymmetricFactory(this.symmetricAlgorithmUri);
+                    symAlg.Key = key;
+                    return symAlg;
+                }
+                return null;
+            }
+            // Fallback to the base implementation
+            return base.GetDecryptionKey(encryptedData, this.symmetricAlgorithmUri);
+        }
+
+        private EncryptedKey GetEncryptedKeyfromKeyInfoClause(EncryptedData encryptedData) {
+            IEnumerator keyInfoEnum = encryptedData.KeyInfo.GetEnumerator();
+            KeyInfoRetrievalMethod kiRetrievalMethod;
+            KeyInfoName kiName;
+            KeyInfoEncryptedKey kiEncKey;
+            EncryptedKey ek = null;
+
+            while (keyInfoEnum.MoveNext()) {
+                kiName = keyInfoEnum.Current as KeyInfoName;
+                if (kiName != null) {
+                    // Get the decryption key from the key mapping
+                    string keyName = kiName.Value;
+                    // try to get it from a CarriedKeyName
+                    XmlNamespaceManager nsm = new XmlNamespaceManager(document.NameTable);
+                    nsm.AddNamespace("enc", EncryptedXml.XmlEncNamespaceUrl);
+                    XmlNodeList encryptedKeyList = document.SelectNodes("//enc:EncryptedKey", nsm);
+                    if (encryptedKeyList != null) {
+                        foreach (XmlNode encryptedKeyNode in encryptedKeyList) {
+                            XmlElement encryptedKeyElement = encryptedKeyNode as XmlElement;
+                            EncryptedKey ek1 = new EncryptedKey();
+                            ek1.LoadXml(encryptedKeyElement);
+                            if (ek1.CarriedKeyName == keyName && ek1.Recipient == Recipient) {
+                                ek = ek1;
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                }
+                kiRetrievalMethod = keyInfoEnum.Current as KeyInfoRetrievalMethod;
+                if (kiRetrievalMethod != null) {
+                    string idref = UriExtensions.ExtractIdFromLocalUri(kiRetrievalMethod.Uri);
+                    ek = new EncryptedKey();
+                    ek.LoadXml(GetIdElement(document, idref));
+                    break;
+                }
+                kiEncKey = keyInfoEnum.Current as KeyInfoEncryptedKey;
+                if (kiEncKey != null) {
+                    ek = kiEncKey.EncryptedKey;
+                    break;
+                }
+            }
+            return ek;
+        }
+
+        //Following https://csrc.nist.gov/csrc/media/publications/fips/140/2/final/documents/fips1402annexa.pdf 
+        //We have only Advanced Encryption Standard(AES) and Triple-DES (TDEA) as valid key encryption and decyption algorithms
+        public static bool IsSymmetricKeyRequiresFipsCompliantImplementation(string symmetricAlgorithmUri) {         
+            if (symmetricAlgorithmUri != null) {
+                // Check if the Uri matches AES256  or TripleDES
+                if (string.Equals(symmetricAlgorithmUri, EncryptedXml.XmlEncAES256Url, StringComparison.InvariantCultureIgnoreCase)) {
+                    return true;
+                };
+                if (string.Equals(symmetricAlgorithmUri, EncryptedXml.XmlEncTripleDESUrl, StringComparison.InvariantCultureIgnoreCase)) {
+                    return true;
+                };
+            }                              
+            return false;
+        }
+
+
+
+
+
+
     }
 }

--- a/Sustainsys.Saml2/Internal/UriExtensions.cs
+++ b/Sustainsys.Saml2/Internal/UriExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -11,6 +13,23 @@ namespace Sustainsys.Saml2.Internal
         public static bool IsHttps(this Uri uri)
         {
             return string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static string ExtractIdFromLocalUri(string uri) {
+            string idref = uri.Substring(1);
+
+            // Deal with XPointer of type #xpointer(id("ID")). Other XPointer support isn't handled here and is anyway optional 
+            if (idref.StartsWith("xpointer(id(", StringComparison.Ordinal)) {
+                int startId = idref.IndexOf("id(", StringComparison.Ordinal);
+                int endId = idref.IndexOf(")", StringComparison.Ordinal);
+                if (endId < 0 || endId < startId + 3) {
+                    throw new CryptographicException("Invalid XML Cryptography Reference");
+                }                
+                idref = idref.Substring(startId + 3, endId - startId - 3);
+                idref = idref.Replace("\'", "");
+                idref = idref.Replace("\"", "");
+            }
+            return idref;
         }
     }
 }

--- a/Tests/Tests.Shared/Helpers/CryptographyHelper.cs
+++ b/Tests/Tests.Shared/Helpers/CryptographyHelper.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Text;
+using System.Xml;
+using Sustainsys.Saml2.Internal;
+
+namespace Sustainsys.Saml2.Tests.Helpers {
+    internal static class CryptographyHelper {
+        internal static void EncryptWithClause(this XmlElement elementToEncrypt, bool useOaep, X509Certificate2 certificate
+            , string keyInfoClauseString, string keyName, string encryptionAlgorithm, bool generateKeyInfo, bool loadEncryptedMethod
+            , bool loadEncryptedKey ,out EncryptedData encriptedDataOut) {
+            if (certificate == null)
+                throw new ArgumentNullException(nameof(certificate));
+            string uriID = "#_12345";
+            string[] args = new string[2] { keyName, uriID };
+
+           var encryptedData = new EncryptedData
+            {
+                Type = EncryptedXml.XmlEncElementUrl,               
+            };
+			if (loadEncryptedMethod) {
+                encryptedData.EncryptionMethod = new EncryptionMethod(encryptionAlgorithm);
+            }
+
+            var algorithm = useOaep ? EncryptedXml.XmlEncRSAOAEPUrl : EncryptedXml.XmlEncRSA15Url;
+            var encryptedKey = new EncryptedKey()
+            {
+                EncryptionMethod = new EncryptionMethod(algorithm),
+            };
+
+            var encryptedXml = new EncryptedXml();
+            byte[] encryptedElement;
+
+            using (var symmetricAlgorithm = CryptographyExtensions.SymmetricFactory(encryptedKey.EncryptionMethod.KeyAlgorithm)) {
+                symmetricAlgorithm.KeySize = 256;
+                encryptedKey.CipherData = new CipherData(EncryptedXml.EncryptKey(symmetricAlgorithm.Key, (RSA)certificate.PublicKey.Key, useOaep));                
+                encryptedElement = encryptedXml.EncryptData(elementToEncrypt, symmetricAlgorithm, false);               
+            }
+            encryptedData.CipherData.CipherValue = encryptedElement;
+            if(generateKeyInfo) {
+                encryptedData.KeyInfo = new KeyInfo();
+                encryptedData.KeyInfo.AddClause(KeyInfoClauseFactory(keyInfoClauseString, encryptedKey, args));
+                if(args[0]!= null) {
+                    if (!loadEncryptedKey) {
+                        args[0] = null;
+                    }
+                    encryptedKey.CarriedKeyName = args[0];
+                    encryptedData.KeyInfo.AddClause(new KeyInfoEncryptedKey(encryptedKey));                  
+                }
+                if(keyInfoClauseString == "KeyInfoRetrievalMethod") {
+                    encryptedKey.Id = uriID.Substring(1);
+                    encryptedData.KeyInfo.AddClause(new KeyInfoEncryptedKey(encryptedKey));
+                }
+            }
+            
+            encriptedDataOut = encryptedData;
+            EncryptedXml.ReplaceElement(elementToEncrypt, encryptedData, false);
+        }
+
+        private static KeyInfoClause KeyInfoClauseFactory(string keyInfoClauseString, EncryptedKey encryptedKey, string[] args) 
+        {
+            switch (keyInfoClauseString) {
+                case "KeyInfoEncryptedKey":
+                    return new KeyInfoEncryptedKey(encryptedKey);
+                case "KeyInfoName":
+                    return new KeyInfoName(args[0]);
+                case "KeyInfoRetrievalMethod":
+                    return new KeyInfoRetrievalMethod(args[1]);                  
+                default:
+                        throw new CryptographicException("No keyInfoClause string for factory");
+            }
+        }
+
+    }
+}

--- a/Tests/Tests.Shared/Internal/CryptographyExtensionsTests.cs
+++ b/Tests/Tests.Shared/Internal/CryptographyExtensionsTests.cs
@@ -4,6 +4,9 @@ using Sustainsys.Saml2.TestHelpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Xml;
+using System.Security.Cryptography.Xml;
+using System.Security.Cryptography;
+using NSubstitute.ExceptionExtensions;
 
 namespace Sustainsys.Saml2.Tests.Internal
 {
@@ -43,6 +46,25 @@ namespace Sustainsys.Saml2.Tests.Internal
                 e => e.Encrypt(false, null))
                 .Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("certificate");
+        }
+
+        [TestMethod]
+        public void SymmetricFactory_SendAes256_AesInstanceReturned() 
+        {
+            var symetricInstance = CryptographyExtensions.SymmetricFactory(EncryptedXml.XmlEncAES256Url);
+            symetricInstance.Should().BeOfType(typeof(AesCryptoServiceProvider));
+        }
+
+        [TestMethod]
+        public void SymmetricFactory_SendTripleDES_TripleDESInstanceReturned() {
+            var symetricInstance = CryptographyExtensions.SymmetricFactory(EncryptedXml.XmlEncTripleDESUrl);
+            symetricInstance.Should().BeOfType(typeof(TripleDESCryptoServiceProvider));
+        }
+
+        [TestMethod]
+        public void SymmetricFactory_SendOtherAlgorithmNoFips_AesInstanceReturned() {
+            var symetricInstance = CryptographyExtensions.SymmetricFactory(EncryptedXml.XmlEncAES128Url);
+            symetricInstance.Should().BeOfType(typeof(AesCryptoServiceProvider));
         }
     }
 }

--- a/Tests/Tests.Shared/Internal/RSAEncryptedXmlTests.cs
+++ b/Tests/Tests.Shared/Internal/RSAEncryptedXmlTests.cs
@@ -1,0 +1,166 @@
+﻿using FluentAssertions;
+using Sustainsys.Saml2.Internal;
+using Sustainsys.Saml2.TestHelpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Security.Cryptography.Xml;
+using System.Security.Cryptography;
+using Sustainsys.Saml2.Tests.Helpers;
+using System.Collections;
+
+namespace Sustainsys.Saml2.Tests.Internal {
+    [TestClass]
+    public class RSAEncryptedXmlTests {
+
+       private EncryptedData _encryptedData;
+
+        [TestMethod]
+        public void GetDecryptionKey_KeyInfoEncryptedKeyNode_Decrypted() {
+                var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoEncryptedKey", true);
+                exml.GetDecryptionKey(_encryptedData, null).Should().BeOfType(typeof(AesCryptoServiceProvider));          
+        }
+        //If Fips is enabled in machine then a Cryptographic exception is expected on base implementation
+        //Then if no fips enabled we expect to have a  RijndaelManaged instance for this scenario
+        [TestMethod]
+        public void GetDecryptionKey_NonFipsAlgorithm_SymmetricAlgorithmReturned() {         
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES192Url, "KeyInfoEncryptedKey", true, null, true, true, true, false);
+            if (CryptoConfig.AllowOnlyFipsAlgorithms) {
+                exml.Invoking(e => e.GetDecryptionKey(_encryptedData, null)).Should().Throw<CryptographicException>();
+            }else {
+                exml.GetDecryptionKey(_encryptedData, null).Should().BeOfType(typeof(RijndaelManaged));
+            }           
+        }
+
+        [TestMethod]
+        public void GetDecryptionKey_NullEncryptedData_ThrowArgumentNullException() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoEncryptedKey", true);
+            exml.Invoking(e => e.GetDecryptionKey(null, null)).Should().Throw<ArgumentNullException>()
+                 .Where(e => e.ParamName.Equals("No Encrypted Data Provided"));           
+        }
+
+
+        [TestMethod]
+        public void GetDecryptionKey_NullKeyInfo_NullReturned() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoEncryptedKey", false);
+            exml.GetDecryptionKey(_encryptedData, null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetDecryptionKey_NoEncryptedMethod_ThrowCryptographicException() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoEncryptedKey", true, null, false);
+            exml.Invoking(e => e.GetDecryptionKey(_encryptedData, null)).Should().Throw<CryptographicException>()
+                 .Where(e => e.Message.Equals("No Cryptograpy algorithm provided in encryption method"));
+        }
+
+        [TestMethod]
+        public void GetDecryptionKey_NoKeyResolved_ThrowCryptographicException() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoEncryptedKey", true, null, true, false);
+            exml.Invoking(e => e.GetDecryptionKey(_encryptedData, null)).Should().Throw<CryptographicException>()
+                 .Where(e => e.Message.Equals("No Decryption Key found"));
+        }
+
+        [TestMethod]
+        public void GetDecryptionKey_NoEncryptedKeyLoaded_ReturnNull() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoName", true, null, true, false, false);           
+            exml.GetDecryptionKey(_encryptedData, null).Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetEncryptedKeyfromKeyInfoClause_KeyName_SymmetricAlgorithmReturned() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoName", true, "AESKey");
+            exml.GetDecryptionKey(_encryptedData, null).Should().BeOfType(typeof(AesCryptoServiceProvider));
+        }
+
+        [TestMethod]
+        public void GetEncryptedKeyfromKeyInfoClause_KeyInfoRetrievalMethod_SymmetricAlgorithmReturned() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoRetrievalMethod", true);
+            exml.GetDecryptionKey(_encryptedData, null).Should().BeOfType(typeof(AesCryptoServiceProvider));
+        }
+
+        [TestMethod]
+        public void IsSymmetricKeyRequiresFipsCompliantImplementation_TripleDESUri_ReturnTrue() {
+            RSAEncryptedXml.IsSymmetricKeyRequiresFipsCompliantImplementation(EncryptedXml.XmlEncTripleDESUrl).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsSymmetricKeyRequiresFipsCompliantImplementation_NoFipsUri_ReturnFalse() {
+            RSAEncryptedXml.IsSymmetricKeyRequiresFipsCompliantImplementation(EncryptedXml.XmlEncAES192Url).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void DecryptEncryptedKey_DecryptOpaep_ByteArrayReturne() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoEncryptedKey", true);
+            IEnumerator keyInfoEnum = _encryptedData.KeyInfo.GetEnumerator();
+            EncryptedKey ek;
+            while (keyInfoEnum.MoveNext()){
+                KeyInfoEncryptedKey ki = keyInfoEnum.Current as KeyInfoEncryptedKey;
+                ek = ki.EncryptedKey;
+                exml.DecryptEncryptedKey(ek).Should().BeOfType(typeof(byte[]));
+                break;
+            }                       
+        }
+
+        [TestMethod]
+        public void DecryptEncryptedKey_DecryptNotOpaep_ByteArrayReturne() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoEncryptedKey", true, null, true, true, true, false);
+            IEnumerator keyInfoEnum = _encryptedData.KeyInfo.GetEnumerator();
+            EncryptedKey ek;
+            while (keyInfoEnum.MoveNext()) {
+                KeyInfoEncryptedKey ki = keyInfoEnum.Current as KeyInfoEncryptedKey;
+                ek = ki.EncryptedKey;
+                exml.DecryptEncryptedKey(ek).Should().BeOfType(typeof(byte[]));
+                break;
+            }
+        }
+
+        [TestMethod]
+        public void DecryptEncryptedKey_NullEncryptedKey_ThrowArgumentNullException() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoEncryptedKey", true);
+            exml.Invoking(e => e.DecryptEncryptedKey(null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void DecryptEncryptedKey_NullOrEmptyCypherValue_ThrowNotImplementedException() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoEncryptedKey", true);
+            IEnumerator keyInfoEnum = _encryptedData.KeyInfo.GetEnumerator();
+            EncryptedKey ek;
+            while (keyInfoEnum.MoveNext()) {
+                KeyInfoEncryptedKey ki = keyInfoEnum.Current as KeyInfoEncryptedKey;
+                ek = ki.EncryptedKey;
+                ek.CipherData.CipherValue = new byte[] {};
+                exml.Invoking(e => e.DecryptEncryptedKey(ek)).Should().Throw<NotImplementedException>()
+                   .Where(e => e.Message.Equals("Unable to decode CipherData of type \"CipherReference\"."));
+                break;
+            }
+        }
+
+        [TestMethod]
+        public void DecryptEncryptedKey_NullPrivateKey_ReturnNull() {
+            var exml = InitializeTestXMLElements(EncryptedXml.XmlEncAES256Url, "KeyInfoEncryptedKey", true, null, true, false, true);
+            IEnumerator keyInfoEnum = _encryptedData.KeyInfo.GetEnumerator();
+            EncryptedKey ek;
+            while (keyInfoEnum.MoveNext()) {
+                KeyInfoEncryptedKey ki = keyInfoEnum.Current as KeyInfoEncryptedKey;
+                ek = ki.EncryptedKey;
+                exml.DecryptEncryptedKey(ek).Should().BeNull();
+                break;
+            }
+        }
+
+        private RSAEncryptedXml InitializeTestXMLElements(string encryptionAlgorithm, string keyInfoClause
+            ,bool generateKeyInfo, string keyName = null, bool loadEncryptedMethod = true, bool sendKey = true
+            ,bool loadEncryptedKey = true, bool useOpaep = true) {
+            RSA key = null;
+            var xmlDoc = XmlHelpers.XmlDocumentFromString("<xml />");
+            var elementToEncrypt = xmlDoc.DocumentElement;
+            elementToEncrypt.EncryptWithClause(useOpaep, SignedXmlHelper.TestCert
+                , keyInfoClause, keyName, encryptionAlgorithm, generateKeyInfo , loadEncryptedMethod, loadEncryptedKey
+                , out var encryptedData);
+            _encryptedData = encryptedData;
+			if (sendKey) {
+                key = (RSA)SignedXmlHelper.TestCert.PrivateKey;
+			}
+            return new RSAEncryptedXml(xmlDoc, key);
+        }
+    }
+}

--- a/Tests/Tests.Shared/Internal/UriExtensionsTests.cs
+++ b/Tests/Tests.Shared/Internal/UriExtensionsTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+using Sustainsys.Saml2.Internal;
+
+namespace Sustainsys.Saml2.Tests.Internal {
+    [TestClass]
+    public class UriExtensionsTests {
+        
+        [TestMethod]
+        public void ExtractIdFromLocalUri_DefaultUri_RemovedHash() {
+            var subject = UriExtensions.ExtractIdFromLocalUri("#_cda7be982d6d9c1052f7f8d439869c8f");
+            subject.Should().Be("_cda7be982d6d9c1052f7f8d439869c8f");
+        }
+
+        [TestMethod]
+        public void ExtractIdFromLocalUri_UriWithSlash_RemovedHashAndSlash() {
+            var subject = UriExtensions.ExtractIdFromLocalUri("#_cda7be982d6d9c1052f7f8d439869c8f\'");
+            subject.Should().Be("_cda7be982d6d9c1052f7f8d439869c8f'");
+        }
+
+        [TestMethod]
+        public void ExtractIdFromLocalUri_UriWithXPointer_RemovedHashAndIdString() {
+            var subject = UriExtensions.ExtractIdFromLocalUri("#xpointer(id(cda7be982d6d9c1052f7f8d439869c8f)ss");
+            subject.Should().Be("cda7be982d6d9c1052f7f8d439869c8f");
+        }
+    }
+}

--- a/Tests/Tests.Shared/Tests.Shared.projitems
+++ b/Tests/Tests.Shared/Tests.Shared.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionTestHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtendedMetadataSerializerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FederationTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\CryptographyHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\SpinWaiter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\XmlElementExtensions.cs" />
@@ -46,6 +47,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Internal\EnumeratorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\PathHelperTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\QueryStringHelperTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\RSAEncryptedXmlTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\UriExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\XDocumentExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ManagedSHA256SignatureDescriptionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Metadata\ContactTypeHelpersTests.cs" />


### PR DESCRIPTION
-Changed CryptographicExtensions class to use AesCryptoServiceProvider instance for FIPS valid algorithm.
-Changed and override decrypt methods from .Net on RSAEncryptedXML class for creating fips algorithm valid instances, avoid using CreateFromName method.
-Added Test methods for RSAEncryptedXML class and CryptographicExtensions as well as a helper class for test initialization.