### PR TITLE
Support loading via byte array instead of via Uri

### DIFF
--- a/Sustainsys.Saml2/Metadata/MetadataLoader.cs
+++ b/Sustainsys.Saml2/Metadata/MetadataLoader.cs
@@ -80,14 +80,14 @@ namespace Sustainsys.Saml2.Metadata
 
 
         /// <summary>
-        /// Load and parse metadata.
+        /// Load and parse metadata directly from a byte array
         /// </summary>
         /// <param name="metadataBytes">byte array of metadata</param>
         /// <returns>EntityDescriptor containing metadata</returns>
-        public static EntityDescriptor LoadIdp(byte[] metadataBytes) => LoadIdp(metadataBytes, false);
+        public static EntityDescriptor LoadIdpFromBytes(byte[] metadataBytes) => LoadIdpFromBytes(metadataBytes, false);
 
         /// <summary>
-        /// Load and parse metadata.
+        /// Load and parse metadata directly from a byte array
         /// </summary>
         /// <param name="metadataBytes">byte array of metadata</param>
         /// <param name="unpackEntitiesDescriptor">If the metadata contains
@@ -101,7 +101,7 @@ namespace Sustainsys.Saml2.Metadata
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "EntityDescriptor")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "IdentityProvider")]
 
-        public static EntityDescriptor LoadIdp(byte[] metadataBytes, bool unpackEntitiesDescriptor)
+        public static EntityDescriptor LoadIdpFromBytes(byte[] metadataBytes, bool unpackEntitiesDescriptor)
         {
             if (metadataBytes == null)
             {


### PR DESCRIPTION
This can be tested crudely by doing this in the asp.net core startup. Obviously normally this would be from a local file or something like that.

```
services.AddAuthentication()
                .AddSaml2(options => 
                {
                    options.SPOptions.EntityId = new EntityId("https://localhost:44342/Saml2");
                    options.IdentityProviders.Add(
                        new IdentityProvider(
                            new EntityId("https://localhost:44300/Metadata"), options.SPOptions)
                        {
                            MetadataBytes = new System.Net.Http.HttpClient().GetByteArrayAsync("https://localhost:44300/Metadata").Result
                        });

                    options.SPOptions.ServiceCertificates.Add(new X509Certificate2("Sustainsys.Saml2.Tests.pfx"));
                });
```