### PR TITLE
Add custom ACS error handler

### DIFF
--- a/Sustainsys.Saml2.Owin/Saml2AuthenticationHandler.cs
+++ b/Sustainsys.Saml2.Owin/Saml2AuthenticationHandler.cs
@@ -94,6 +94,9 @@ namespace Sustainsys.Saml2.Owin
             authProperties.RedirectUri = WebUtilities.AddQueryString(
                 authProperties.RedirectUri, "error", "access_denied");
 
+            authProperties.RedirectUri = Options.Notifications.HandleAcsCommandError(ex, authProperties.RedirectUri)
+                ?? authProperties.RedirectUri;
+
             string samlResponse = ex.Data.Contains("Saml2Response")
                 ? " The received SAML data is\n" + ex.Data["Saml2Response"]
                 : "";

--- a/Sustainsys.Saml2/Configuration/Saml2Notifications.cs
+++ b/Sustainsys.Saml2/Configuration/Saml2Notifications.cs
@@ -120,6 +120,15 @@ namespace Sustainsys.Saml2.Configuration
          = (cr, r) => { };
 
         /// <summary>
+        /// Notification called when the ACS command encounters an error while
+        /// processing the SAML response. Receives an exception and the
+        /// candidate redirect Url, return a non-null string if you need
+        /// to override the redirect per request.
+        /// </summary>
+        public Func<Exception, string, string> HandleAcsCommandError { get; set; }
+            = (ex, url) => null;
+
+        /// <summary>
         /// Notification called when the Logout command has produced a
         /// <see cref="CommandResult"/>, but before anything has been applied
         /// to the outgoing response. Set the <see cref="CommandResult.HandledResult"/>

--- a/Sustainsys.Saml2/WebSSO/AcsCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/AcsCommand.cs
@@ -44,6 +44,7 @@ namespace Sustainsys.Saml2.WebSso
             if (binding != null)
             {
                 UnbindResult unbindResult = null;
+                IdentityProvider idpContext = null;
                 try
                 {
                     unbindResult = binding.Unbind(request, options);
@@ -52,7 +53,7 @@ namespace Sustainsys.Saml2.WebSso
 
                     var samlResponse = new Saml2Response(unbindResult.Data, request.StoredRequestState?.MessageId, options);
                     
-                    var idpContext = GetIdpContext(unbindResult.Data, request, options);
+                    idpContext = GetIdpContext(unbindResult.Data, request, options);
 
                     var result = ProcessResponse(options, samlResponse, request.StoredRequestState, idpContext, unbindResult.RelayState);
 
@@ -90,6 +91,10 @@ namespace Sustainsys.Saml2.WebSso
                     {
                         // Add the payload to the existing exception
                         ex.Data["Saml2Response"] = unbindResult.Data.OuterXml;
+                    }
+                    if (idpContext != null)
+                    {
+                        ex.Data["Saml2IdP"] = idpContext.EntityId.Id;
                     }
                     throw;
                 }


### PR DESCRIPTION
This allows using a custom error handler with the AcsCommand. The command receives the exception, and can optionally redirect the user to a different URL.

I've only implemented for OWIN for now, as I'm looking for feedback on the approach (per contribution guidelines).

Example usage:

```csharp
saml2Options.Notifications.HandleAcsCommandError = (ex, url) =>
{
    // Allow IdP-initiated login (eg: from Okta portal) without opening up to replay attacks
    if (ex is Saml2ResponseFailedValidationException
        && ex.Message.StartsWith("Unsolicited responses are not allowed")
        && ex.Data.Contains("Saml2IdP"))
    {
        var idpId = (string)ex.Data["Saml2IdP"];
        return $"/Account/ExternalLogin?idpid={Uri.EscapeDataString(idpId)}";
    }

    // Track the offending IdP and show the user a correlated error code for support tickets
    var logProperties = new Dictionary<string, string>();
    if (ex.Data.Contains("Saml2Response"))
    {
        logProperties.Add("Saml2_Response", (string)ex.Data["Saml2Response"]);
    }
    if (ex.Data.Contains("Saml2IdP"))
    {
        logProperties.Add("Saml2_IdentityProvider", (string)ex.Data["Saml2IdP"]);
    }
    var errorCode = LogHelper.LogError(ex, "Saml2.AuthenticationFailed", logProperties);
    return $"/Error?code={Uri.EscapeDataString(errorCode.ToString())}";
};
```

The pattern is inspired by the OWIN OpenIdConnect [AuthenticationFailed](https://docs.microsoft.com/en-us/dotnet/api/microsoft.owin.security.openidconnect.openidconnectauthenticationnotifications.authenticationfailed?view=owin-4.1) notification (see [example](https://docs.microsoft.com/en-us/azure/active-directory/develop/tutorial-v2-asp-webapp#configure-the-authentication-pipeline)). But to avoid tying directly to `Microsoft.Owin.Security`, it simply allows returning a redirect URL string.

@AndersAbel what are your thoughts? If you're happy with this change then I'll add tests and implement for `AspNetCore2`, `HttpModule`, `Mvc`.