### PR TITLE
Re-Add the functionality to exclude SpSso creation

### DIFF
--- a/Sustainsys.Saml2/Metadata/ExtendedMetadataSerializer.cs
+++ b/Sustainsys.Saml2/Metadata/ExtendedMetadataSerializer.cs
@@ -55,15 +55,14 @@ namespace Sustainsys.Saml2.Metadata
             }
         }
 
-
-#if FALSE
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
-        protected override ServiceProviderSingleSignOnDescriptor ReadServiceProviderSingleSignOnDescriptor(XmlReader reader)
+        protected override SpSsoDescriptor ReadSpSsoDescriptor(XmlReader reader)
         {
             reader.Skip();
-            return CreateServiceProviderSingleSignOnDescriptorInstance();
+            return CreateSpSsoDescriptorInstance();
         }
 
+#if FALSE
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
         protected override Organization ReadOrganization(XmlReader reader)
         {

--- a/Tests/Tests.Shared/ExtendedMetadataSerializerTests.cs
+++ b/Tests/Tests.Shared/ExtendedMetadataSerializerTests.cs
@@ -278,15 +278,13 @@ gosrSG6sO3IPeL4BncKqqZO2FokfZbaqPBv6xmoKsVTUTQRfNEks84dRiG0MjqBncR+B6CIrCv2a
         [TestMethod]
         public void ExtendedMetadataSerializer_Read_ServiceProviderSingleSignOnDescriptor()
         {
-			// TODO: I don't understand what this test was doing originally -- it was checking that there 
-			// were zero AssertionConsumerServices results from adding two with identical indexes (
-			// which is illegal as far as I can tell from the specification)
+			// This test is dealing with the issue of SPs having duplicate index numbers on their AssertionConsumerServices
             var data =
 @"<md:EntityDescriptor xmlns:md=""urn:oasis:names:tc:SAML:2.0:metadata"" entityID=""http://idp-acc.test.ek.sll.se/neas"">
     <md:SPSSODescriptor AuthnRequestsSigned=""false"" WantAssertionsSigned=""true"" protocolSupportEnumeration=""urn:oasis:names:tc:SAML:2.0:protocol"">
       <md:SingleLogoutService Binding=""urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"" Location=""https://maggie.bif.ost.se:9443/sp/saml/slo/HTTP-POST""/>
       <md:AssertionConsumerService Binding=""urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"" Location=""https://maggie.bif.ost.se:9443/sp/saml/sso/HTTP-POST"" index=""1"" isDefault=""true""/>
-      <md:AssertionConsumerService Binding=""urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"" Location=""https://maggie.bif.ost.se:9443/sp/saml/sso/POST"" index=""2"" isDefault=""true""/>
+      <md:AssertionConsumerService Binding=""urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"" Location=""https://maggie.bif.ost.se:9443/sp/saml/sso/POST"" index=""1"" isDefault=""true""/>
 	</md:SPSSODescriptor>
  </md:EntityDescriptor>";
 
@@ -295,7 +293,7 @@ gosrSG6sO3IPeL4BncKqqZO2FokfZbaqPBv6xmoKsVTUTQRfNEks84dRiG0MjqBncR+B6CIrCv2a
 
             var spssoInfo = entityDescriptor.RoleDescriptors.Cast<SpSsoDescriptor>().Single();
 
-            spssoInfo.AssertionConsumerServices.Count.Should().Be(2);
+            spssoInfo.AssertionConsumerServices.Count.Should().Be(0);
         }
 
         [TestMethod]


### PR DESCRIPTION
This pull request deals with #1270 in v2.

The functionality for excluding the creation of SpSsoDescriptors is reenabled and migrated according to the new naming structure.
A test is altered to the state it was initially in on creation, for dealing with the linked issue.