### PR TITLE
Case insensitivity on ModulePath

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/Saml2Handler.cs
+++ b/Sustainsys.Saml2.AspNetCore2/Saml2Handler.cs
@@ -117,7 +117,7 @@ namespace Sustainsys.Saml2.AspNetCore2
         /// <InheritDoc />
         public async Task<bool> HandleRequestAsync()
         {
-            if (context.Request.Path.StartsWithSegments(options.SPOptions.ModulePath, StringComparison.Ordinal))
+            if (context.Request.Path.StartsWithSegments(options.SPOptions.ModulePath, StringComparison.OrdinalIgnoreCase))
             {
                 var commandName = context.Request.Path.Value.Substring(
                     options.SPOptions.ModulePath.Length).TrimStart('/');

--- a/Sustainsys.Saml2.Owin/Extensions/PathStringExtensions.cs
+++ b/Sustainsys.Saml2.Owin/Extensions/PathStringExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.Owin;
+
+namespace Sustainsys.Saml2.Owin.Extensions
+{
+    /// <summary>
+    /// Extension helpers for <see cref="PathString"/>.
+    /// </summary>
+    public static class PathStringExtensions
+    {
+        // Based on the aspnet core implementation:
+        // https://github.com/dotnet/aspnetcore/blob/c925f99cddac0df90ed0bc4a07ecda6b054a0b02/src/Http/Http.Abstractions/src/PathString.cs
+
+        /// <summary>
+        /// Determines whether the beginning of this <see cref="PathString"/> instance matches the specified <see cref="PathString"/> when compared
+        /// using the specified comparison option and returns the remaining segments.
+        /// </summary>
+        /// <param name="value">The source <see cref="PathString"/>.</param>
+        /// <param name="other">The <see cref="PathString"/> to compare.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how this <see cref="PathString"/> and value are compared.</param>
+        /// <param name="remaining">The remaining segments after the match.</param>
+        /// <returns>true if value matches the beginning of this string; otherwise, false.</returns>
+        public static bool StartsWithSegments(this PathString value, PathString other, StringComparison comparisonType, out PathString remaining)
+        {
+            var value1 = value.Value ?? string.Empty;
+            var value2 = other.Value ?? string.Empty;
+            if (value1.StartsWith(value2, comparisonType))
+            {
+                if (value1.Length == value2.Length || value1[value2.Length] == '/')
+                {
+                    remaining = new PathString(value1.Substring(value2.Length));
+                    return true;
+                }
+            }
+            remaining = PathString.Empty;
+            return false;
+        }
+    }
+}

--- a/Sustainsys.Saml2.Owin/Saml2AuthenticationHandler.cs
+++ b/Sustainsys.Saml2.Owin/Saml2AuthenticationHandler.cs
@@ -1,16 +1,14 @@
-﻿using Sustainsys.Saml2.Configuration;
-using Sustainsys.Saml2.Metadata;
-using Sustainsys.Saml2.WebSso;
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.Owin;
 using Microsoft.Owin.Infrastructure;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Infrastructure;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Claims;
-using System.Text;
-using System.Threading.Tasks;
+using Sustainsys.Saml2.Metadata;
+using Sustainsys.Saml2.Owin.Extensions;
+using Sustainsys.Saml2.WebSso;
 
 namespace Sustainsys.Saml2.Owin
 {
@@ -197,7 +195,7 @@ namespace Sustainsys.Saml2.Owin
         {
             var Saml2Path = new PathString(Options.SPOptions.ModulePath);
 
-            if (Request.Path.StartsWithSegments(Saml2Path, out PathString remainingPath))
+            if (Request.Path.StartsWithSegments(Saml2Path, StringComparison.OrdinalIgnoreCase, out PathString remainingPath))
             {
                 if (remainingPath == new PathString("/" + CommandFactory.AcsCommandName))
                 {

--- a/Sustainsys.Saml2.Owin/Sustainsys.Saml2.Owin.csproj
+++ b/Sustainsys.Saml2.Owin/Sustainsys.Saml2.Owin.csproj
@@ -65,6 +65,7 @@
     </Compile>
     <Compile Include="CommandResultExtensions.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="Extensions\PathStringExtensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="OwinRequestExtensions.cs" />
     <Compile Include="Saml2AuthenticationExtensions.cs" />

--- a/Tests/AspNetCore2.Tests/Saml2HandlerTests.cs
+++ b/Tests/AspNetCore2.Tests/Saml2HandlerTests.cs
@@ -79,7 +79,7 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
                         };
 
                         idp.SigningKeys.AddConfiguredKey(SignedXmlHelper.TestCert);
-                        
+
                         opt.IdentityProviders.Add(idp);
                         opt.IdentityProviders.Add(secondIdp);
 
@@ -128,7 +128,7 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
             var cookieManager = Substitute.For<ICookieManager>();
             context.Subject.options.CookieManager = cookieManager;
 
-            var authProps = new AuthenticationProperties {RedirectUri = "https://sp.example.com/LoggedIn"};
+            var authProps = new AuthenticationProperties { RedirectUri = "https://sp.example.com/LoggedIn" };
 
             var response = context.HttpContext.Response;
 
@@ -139,9 +139,9 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
 
             cookieManager.Received().AppendResponseCookie(
                 Arg.Any<HttpContext>(),
-                Arg.Is<string>(value => value.StartsWith( "Saml2." )),
+                Arg.Is<string>(value => value.StartsWith("Saml2.")),
                 Arg.Any<string>(),
-                Arg.Is<CookieOptions>(c => c.HttpOnly && c.Path == "/" ));
+                Arg.Is<CookieOptions>(c => c.HttpOnly && c.Path == "/"));
         }
 
         [TestMethod]
@@ -230,12 +230,16 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
         }
 
         [TestMethod]
-        public async Task Saml2Handler_Acs_Works()
+        [DataRow("/Saml2/Acs")]
+        [DataRow("/SAML2/ACS")]
+        [DataRow("/saml2/acs")]
+        [DataRow("/SaMl2/AcS")]
+        public async Task Saml2Handler_Acs_Works(string acsPath)
         {
             var context = new Saml2HandlerTestContext();
 
             context.HttpContext.Request.Method = "POST";
-            context.HttpContext.Request.Path = "/Saml2/Acs";
+            context.HttpContext.Request.Path = acsPath;
 
             var authProps = new AuthenticationProperties()
             {
@@ -388,8 +392,8 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
                 "Content-Disposition",
                 "attachment; filename=\"sp.example.com_saml2.xml\"");
 
-			var ms = context.HttpContext.Response.Body.As<MemoryStream>();
-			Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length)
+            var ms = context.HttpContext.Response.Body.As<MemoryStream>();
+            Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length)
                 .Should().StartWith("<EntityDescriptor");
         }
 
@@ -456,7 +460,7 @@ namespace Sustainsys.Saml2.AspNetCore2.Tests
         public void Saml2Handler_SignOutAsync_NullcheckProperties()
         {
             var context = new Saml2HandlerTestContext();
-            
+
             Func<Task> f = async () => await context.Subject.SignOutAsync(null);
 
             f.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("properties");

--- a/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
@@ -1142,7 +1142,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             Action a = () => Saml2Response.Read(signedResponse).GetClaims(options);
 
             a.Should().Throw<Saml2ResponseFailedValidationException>()
-                .WithMessage("Encrypted Assertion(s) could not be decrypted using the configured Service Certificate(s).");
+                .WithMessage("Encrypted Assertion(s) could not be decrypted using the configured Service Certificate(s)");
         }
 
         [TestMethod]


### PR DESCRIPTION
This is a pull request targeting branch `v2` for Framework & Core2 implementations.  

This resolves the issue of the Saml2 handler only listening for requests that start with the **case sensitive** module path.  This allows for case insensitivity resolving #570 

This COULD potentially be breaking if current consumers rely on the path to be exact case.  If this is a large concern, I'm open to providing a parameter on `SPOptions` which defines if comparisons should be sensitive or not with a default of case-sensitive comparisons