### PR TITLE
SP initiated authnRequest binding problem fix

### DIFF
--- a/Sustainsys.Saml2/IdentityProvider.cs
+++ b/Sustainsys.Saml2/IdentityProvider.cs
@@ -309,7 +309,8 @@ namespace Sustainsys.Saml2
                 AttributeConsumingServiceIndex = spOptions.AttributeConsumingServices.Any() ? 0 : (int?)null,
                 NameIdPolicy = spOptions.NameIdPolicy,
                 RequestedAuthnContext = spOptions.RequestedAuthnContext,
-                SigningAlgorithm = this.OutboundSigningAlgorithm
+                SigningAlgorithm = this.OutboundSigningAlgorithm,
+                Binding = this.Binding
             };
 
             if (spOptions.AuthenticateRequestSigningBehavior == SigningBehavior.Always


### PR DESCRIPTION
CreateAuthenticateRequest in IdentityProvider don't send binding method on request. I fixed this issue at Saml2AuthenticationRequest initialize time on CreateAuthenticateRequest. 