### PR TITLE
Add HttpRequestData<T> for notification context

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/HttpRequestExtensions.cs
+++ b/Sustainsys.Saml2.AspNetCore2/HttpRequestExtensions.cs
@@ -10,7 +10,7 @@ namespace Sustainsys.Saml2.AspNetCore2
 {
     static class HttpRequestExtensions
     {
-        public static HttpRequestData ToHttpRequestData(
+        public static HttpRequestData<HttpContext> ToHttpRequestData(
             this HttpContext httpContext,
             ICookieManager cookieManager,
             Func<byte[], byte[]> cookieDecryptor)
@@ -33,7 +33,8 @@ namespace Sustainsys.Saml2.AspNetCore2
                     f => new KeyValuePair<string, IEnumerable<string>>(f.Key, f.Value));
             }
 
-            return new HttpRequestData(
+            return new HttpRequestData<HttpContext>(
+                httpContext,
                 httpContext.Request.Method,
                 uri,
                 pathBase,

--- a/Sustainsys.Saml2.Mvc/HttpRequestBaseExtensions.cs
+++ b/Sustainsys.Saml2.Mvc/HttpRequestBaseExtensions.cs
@@ -51,7 +51,8 @@ namespace Sustainsys.Saml2.HttpModule
                 ? Enumerable.Empty<KeyValuePair<string, string>>()
                 : GetCookies(requestBase);
 
-            return new HttpRequestData(
+            return new HttpRequestData<HttpRequestBase>(
+                requestBase,
                 requestBase.HttpMethod,
                 requestBase.Url,
                 requestBase.ApplicationPath,

--- a/Sustainsys.Saml2/Configuration/Saml2Notifications.cs
+++ b/Sustainsys.Saml2/Configuration/Saml2Notifications.cs
@@ -51,9 +51,9 @@ namespace Sustainsys.Saml2.Configuration
         /// in selection.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
-        public Func<EntityId, IDictionary<string, string>, IdentityProvider>
+        public Func<object, EntityId, IDictionary<string, string>, IOptions, IdentityProvider>
             SelectIdentityProvider
-        { get; set; } = (ei, r) => null;
+        { get; set; } = (ctx, ei, rd, opt) => null;
 
         /// <summary>
         /// Notification called to decide if a SameSite=None attribute should
@@ -179,8 +179,8 @@ namespace Sustainsys.Saml2.Configuration
         /// Notification called when getting an identity provider. Default version is to return
         /// the given idp from Options.IdentityProviders.
         /// </summary>
-        public Func<EntityId, IDictionary<string, string>, IOptions, IdentityProvider> GetIdentityProvider { get; set; }
-            = (ei, rd, opt) => opt.IdentityProviders[ei];
+        public Func<object, EntityId, IDictionary<string, string>, IOptions, IdentityProvider> GetIdentityProvider { get; set; }
+            = (ctx, ei, rd, opt) => opt.IdentityProviders[ei];
 
         /// <summary>
         /// Callbacks that allow modifying the validation behavior in potentially unsafe/insecure ways

--- a/Sustainsys.Saml2/SAML2P/Saml2Response.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2Response.cs
@@ -543,24 +543,26 @@ namespace Sustainsys.Saml2.Saml2P
         /// Extract claims from the assertions contained in the response.
         /// </summary>
         /// <param name="options">Service provider settings used when processing the response into claims.</param>
+        /// <param name="context">The target-specific HTTP context.</param>
         /// <returns>ClaimsIdentities</returns>
         // Method might throw expections so make it a method and not a property.
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        public IEnumerable<ClaimsIdentity> GetClaims(IOptions options)
+        public IEnumerable<ClaimsIdentity> GetClaims(IOptions options, object context)
         {
-            return GetClaims(options, null);
+            return GetClaims(options, context, null);
         }
-        
+
         /// <summary>
         /// Extract claims from the assertions contained in the response.
         /// </summary>
         /// <param name="options">Service provider settings used when processing the response into claims.</param>
+        /// <param name="context">The target-specific HTTP context.</param>
         /// <param name="relayData">Relay data stored when creating AuthnRequest, to be passed on to
         /// GetIdentityProvider notification.</param>
         /// <returns>ClaimsIdentities</returns>
         // Method might throw expections so make it a method and not a property.
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        public IEnumerable<ClaimsIdentity> GetClaims(IOptions options, IDictionary<string, string> relayData)
+        public IEnumerable<ClaimsIdentity> GetClaims(IOptions options, object context, IDictionary<string, string> relayData)
         {
             if (createClaimsException != null)
             {
@@ -571,7 +573,7 @@ namespace Sustainsys.Saml2.Saml2P
             {
                 try
                 {
-                    var idp = options.Notifications.GetIdentityProvider(Issuer, relayData, options);
+                    var idp = options.Notifications.GetIdentityProvider(context, Issuer, relayData, options);
                     claimsIdentities = CreateClaims(options, idp).ToList();
 
                     // Validate InResponseTo now, to be able to include generated claims in notification.

--- a/Sustainsys.Saml2/WebSSO/AcsCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/AcsCommand.cs
@@ -54,7 +54,7 @@ namespace Sustainsys.Saml2.WebSso
                     
                     var idpContext = GetIdpContext(unbindResult.Data, request, options);
 
-                    var result = ProcessResponse(options, samlResponse, request.StoredRequestState, idpContext, unbindResult.RelayState);
+                    var result = ProcessResponse(options, samlResponse, request.ContextObject, request.StoredRequestState, idpContext, unbindResult.RelayState);
 
                     if (request.StoredRequestState != null)
                     {
@@ -102,7 +102,7 @@ namespace Sustainsys.Saml2.WebSso
         {
             var entityId = new EntityId(xml["Issuer", Saml2Namespaces.Saml2Name].GetTrimmedTextIfNotNull());
 
-            var identityProvider = options.Notifications.GetIdentityProvider(entityId, request.StoredRequestState?.RelayData, options);
+            var identityProvider = options.Notifications.GetIdentityProvider(request.ContextObject, entityId, request.StoredRequestState?.RelayData, options);
 
             return identityProvider;
         }
@@ -142,11 +142,12 @@ namespace Sustainsys.Saml2.WebSso
         private static CommandResult ProcessResponse(
             IOptions options,
             Saml2Response samlResponse,
+            object contextObject,
             StoredRequestState storedRequestState,
             IdentityProvider identityProvider,
             string relayState)
         {
-            var principal = new ClaimsPrincipal(samlResponse.GetClaims(options, storedRequestState?.RelayData));
+            var principal = new ClaimsPrincipal(samlResponse.GetClaims(options, contextObject, storedRequestState?.RelayData));
             
             if (options.SPOptions.ReturnUrl == null && !identityProvider.RelayStateUsedAsReturnUrl)
             {

--- a/Sustainsys.Saml2/WebSSO/HttpRequestData.cs
+++ b/Sustainsys.Saml2/WebSSO/HttpRequestData.cs
@@ -230,5 +230,10 @@ namespace Sustainsys.Saml2.WebSso
         /// User (if any) associated with the request
         /// </summary>
         public ClaimsPrincipal User { get; set; }
+
+        /// <summary>
+        /// The target-specific HTTP request object.
+        /// </summary>
+        public virtual object ContextObject { get; }
     }
 }

--- a/Sustainsys.Saml2/WebSSO/HttpRequestData`1.cs
+++ b/Sustainsys.Saml2/WebSSO/HttpRequestData`1.cs
@@ -1,0 +1,124 @@
+﻿using Sustainsys.Saml2.Internal;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using System.Security.Claims;
+
+namespace Sustainsys.Saml2.WebSso
+{
+    /// <inheritdoc/>
+    public class HttpRequestData<T> : HttpRequestData
+    {
+        /// <inheritdoc/>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Decryptor")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
+        public HttpRequestData(
+            T context,
+            string httpMethod,
+            Uri url,
+            string applicationPath,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> formData,
+            IEnumerable<KeyValuePair<string, string>> cookies,
+            Func<byte[], byte[]> cookieDecryptor)
+            : base(
+                httpMethod,
+                url,
+                applicationPath,
+                formData,
+                cookies,
+                cookieDecryptor)
+        {
+            Context = context;
+        }
+
+        /// <inheritdoc/>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Decryptor")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
+        public HttpRequestData(
+            T context,
+            string httpMethod,
+            Uri url,
+            string applicationPath,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> formData,
+            IEnumerable<KeyValuePair<string, string>> cookies,
+            Func<byte[], byte[]> cookieDecryptor,
+            ClaimsPrincipal user)
+            : base(
+                httpMethod,
+                url,
+                applicationPath,
+                formData,
+                cookies,
+                cookieDecryptor,
+                user)
+        {
+            Context = context;
+        }
+
+        /// <inheritdoc/>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Decryptor")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
+        public HttpRequestData(
+            T context,
+            string httpMethod,
+            Uri url,
+            string applicationPath,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> formData,
+            Func<string, string> cookieReader,
+            Func<byte[], byte[]> cookieDecryptor,
+            ClaimsPrincipal user)
+            : base(
+                httpMethod,
+                url,
+                applicationPath,
+                formData,
+                cookieReader,
+                cookieDecryptor,
+                user)
+        {
+            Context = context;
+        }
+
+        // Used by tests.
+        internal HttpRequestData(
+            T context,
+            string httpMethod, 
+            Uri url)
+            : base(httpMethod, url)
+        {
+            Context = context;
+        }
+
+        // Used by tests.
+        internal HttpRequestData(
+            T context,
+            string httpMethod,
+            Uri url,
+            string applicationPath,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> formData,
+            StoredRequestState storedRequestState)
+            : base(
+                httpMethod,
+                url,
+                applicationPath,
+                formData,
+                storedRequestState)
+        {
+            Context = context;
+        }
+
+        /// <summary>
+        /// The typed target-specific HTTP request.
+        /// </summary>
+        public T Context;
+
+        /// <inheritdoc/>
+        public override object ContextObject => Context;
+    }
+}

--- a/Sustainsys.Saml2/WebSSO/Saml2ArtifactBinding.cs
+++ b/Sustainsys.Saml2/WebSSO/Saml2ArtifactBinding.cs
@@ -75,18 +75,19 @@ namespace Sustainsys.Saml2.WebSso
 
             options.SPOptions.Logger.WriteVerbose("Artifact binding found Artifact\n" + artifact);
 
-            var data = ResolveArtifact(artifact, request.StoredRequestState, options);
+            var data = ResolveArtifact(artifact, request.ContextObject, request.StoredRequestState, options);
 
             return new UnbindResult(data, relayState, TrustLevel.None);
         }
 
         private static XmlElement ResolveArtifact(
             string artifact,
+            object contextObject,
             StoredRequestState storedRequestState,
             IOptions options)
         {
             var binaryArtifact = Convert.FromBase64String(artifact);
-            var idp = GetIdp(binaryArtifact, storedRequestState, options);
+            var idp = GetIdp(binaryArtifact, contextObject, storedRequestState, options);
             var arsIndex = (binaryArtifact[2] << 8) | binaryArtifact[3];
             var arsUri = idp.ArtifactResolutionServiceUrls[arsIndex];
 
@@ -118,12 +119,13 @@ namespace Sustainsys.Saml2.WebSso
 
         private static IdentityProvider GetIdp(
             byte[] binaryArtifact,
+            object context,
             StoredRequestState storedRequestState,
             IOptions options)
         {
             if(storedRequestState != null)
             {
-                return options.Notifications.GetIdentityProvider(storedRequestState.Idp, storedRequestState.RelayData, options);
+                return options.Notifications.GetIdentityProvider(context, storedRequestState.Idp, storedRequestState.RelayData, options);
             }
 
             // It is RECOMMENDED in the spec that the first part of the artifact

--- a/Sustainsys.Saml2/WebSSO/SignInCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/SignInCommand.cs
@@ -112,7 +112,7 @@ namespace Sustainsys.Saml2.WebSso
 
             var urls = new Saml2Urls(request, options);
 
-            IdentityProvider idp = options.Notifications.SelectIdentityProvider(idpEntityId, relayData);
+            IdentityProvider idp = options.Notifications.SelectIdentityProvider(request.ContextObject, idpEntityId, relayData, options);
             if (idp == null)
             {
                 var idpEntityIdString = idpEntityId?.Id;

--- a/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2ResponseTests.cs
@@ -272,7 +272,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
                 </saml2:Assertion>
             </saml2p:Response>";
 
-            Action a = () => Saml2Response.Read(response).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(response).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<Saml2ResponseFailedValidationException>()
                 .WithMessage("The SAML Response is not signed and contains unsigned Assertions. Response cannot be trusted.");
@@ -304,7 +304,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var signedResponse = SignedXmlHelper.SignXml(response);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
             a.Should().NotThrow();
         }
 
@@ -335,7 +335,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             </saml2p:Response>";
 
             var signedResponse = SignedXmlHelper.SignXml(response);
-			var claims = Saml2Response.Read(signedResponse).GetClaims(StubFactory.CreateOptions());
+			var claims = Saml2Response.Read(signedResponse).GetClaims(StubFactory.CreateOptions(), context: null);
 			claims.Single().FindFirst(
 				"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")
 				.Value.Should().Be("SomeUser");
@@ -374,7 +374,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var signedResponse = SignedXmlHelper.SignXml(response);
 
-            var claims = Saml2Response.Read(signedResponse).GetClaims(StubFactory.CreateOptions());
+            var claims = Saml2Response.Read(signedResponse).GetClaims(StubFactory.CreateOptions(), context: null);
 
             claims.Single().FindFirst("CommentTest").Value.Should().Be("SomeValue");
         }
@@ -419,7 +419,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             options.IdentityProviders.Add(idp);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options, context: null);
             a.Should().NotThrow();
         }
 
@@ -460,7 +460,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var signedResponse = SignedXmlHelper.SignXml(response);
 
-            var result = Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            var result = Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
 
             var logoutInfoClaim = result.Single().Claims.SingleOrDefault(c => c.Type == Saml2ClaimTypes.LogoutNameIdentifier);
             logoutInfoClaim.Should().NotBeNull("the LogoutInfo claim should be generated");
@@ -499,7 +499,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var signedResponse = SignedXmlHelper.SignXml(response);
 
-            var result = Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            var result = Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
 
             var logoutInfoClaim = result.Single().Claims.SingleOrDefault(c => c.Type == Saml2ClaimTypes.LogoutNameIdentifier);
             logoutInfoClaim.Should().NotBeNull("the Logout name identifier claim should be generated");
@@ -541,7 +541,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var signedResponse = SignedXmlHelper.SignXml(response);
 
-            var result = Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            var result = Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
 
             var authMethodClaim = result.Single().Claims.SingleOrDefault(c => c.Type == ClaimTypes.AuthenticationMethod);
             authMethodClaim.Should().NotBeNull("the authentication method claim should be generated");
@@ -581,7 +581,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var options = StubFactory.CreateOptions();
             options.SPOptions.Compatibility.IgnoreAuthenticationContextInResponse = true;
-            var result = Saml2Response.Read(signedResponse).GetClaims(options);
+            var result = Saml2Response.Read(signedResponse).GetClaims(options, context: null);
 
             var authMethodClaim = result.Single().Claims.SingleOrDefault(c => c.Type == ClaimTypes.AuthenticationMethod);
             authMethodClaim.Should().BeNull("the authentication method claim should not be generated");
@@ -624,7 +624,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var options = Options.FromConfiguration;
             options.SPOptions.Saml2PSecurityTokenHandler = new Saml2PSecurityTokenHandler();
-            var result = Saml2Response.Read(signedResponse).GetClaims(options);
+            var result = Saml2Response.Read(signedResponse).GetClaims(options, context: null);
 
             var authMethodClaim = result.Single().Claims.SingleOrDefault(c => c.Type == ClaimTypes.AuthenticationMethod);
             authMethodClaim.Should().NotBeNull("the authentication method claim should be generated");
@@ -662,7 +662,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var signedResponse = SignedXmlHelper.SignXml(response);
 
-            var result = Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            var result = Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
 
             result.First().FindFirst(ClaimTypes.NameIdentifier).Should().BeNull();
 
@@ -701,7 +701,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var signedAssertion = SignedXmlHelper.SignXml(assertion);
             var signedResponse = string.Format(response, signedAssertion);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
             a.Should().NotThrow();
         }
 
@@ -734,7 +734,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var signedAssertion = SignedXmlHelper.SignXml(assertion, true, false);
             var signedResponse = string.Format(response, signedAssertion);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
             a.Should().NotThrow();
         }
 
@@ -779,7 +779,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var signedAssertion2 = SignedXmlHelper.SignXml(assertion2);
             var signedResponse = string.Format(response, signedAssertion1, signedAssertion2);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
             a.Should().NotThrow();
         }
 
@@ -824,7 +824,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var signedAssertion2 = SignedXmlHelper.SignXml(assertion2, true, false);
             var signedResponse = string.Format(response, signedAssertion1, signedAssertion2);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
             a.Should().NotThrow();
         }
 
@@ -869,7 +869,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var signedAssertion1 = SignedXmlHelper.SignXml(assertion1);
             var signedResponse = string.Format(response, signedAssertion1, assertion2);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<Saml2ResponseFailedValidationException>()
                 .WithMessage("The SAML Response is not signed and contains unsigned Assertions. Response cannot be trusted.");
@@ -916,7 +916,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var signedAssertion2 = SignedXmlHelper.SignXml(assertion2).Replace("SomeUser2", "SomeOtherUser");
             var signedResponse = string.Format(response, signedAssertion1, signedAssertion2);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<InvalidSignatureException>()
                 .WithMessage("Signature didn't verify. Have the contents been tampered with?");
@@ -973,7 +973,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var signedResponse = string.Format(response, signedAssertion1, signedAssertionToInject);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<InvalidSignatureException>()
                 .WithMessage("Incorrect reference on Xml signature. The reference must be to the root element of the element containing the signature.");
@@ -996,7 +996,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var samlResponse = Saml2Response.Read(signedResponse);
 
-            Action a = () => samlResponse.GetClaims(Options.FromConfiguration);
+            Action a = () => samlResponse.GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().NotThrow();
             a.Should().NotThrow();
@@ -1033,7 +1033,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var options = StubFactory.CreateOptions();
             options.SPOptions.ServiceCertificates.Add(new ServiceCertificate { Certificate = SignedXmlHelper.TestCert2 });
 
-            var claims = Saml2Response.Read(signedResponse).GetClaims(options);
+            var claims = Saml2Response.Read(signedResponse).GetClaims(options, context: null);
             claims.Count().Should().Be(1);
             claims.First().FindFirst(ClaimTypes.NameIdentifier).Value.Should().Be("UserIDInsideEncryptedAssertion");
         }
@@ -1068,7 +1068,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var encryptedAssertion = SignedXmlHelper.EncryptAssertion(signedAssertion);
             var responseWithAssertion = string.Format(response, encryptedAssertion);
 
-            var claims = Saml2Response.Read(responseWithAssertion).GetClaims(Options.FromConfiguration);
+            var claims = Saml2Response.Read(responseWithAssertion).GetClaims(Options.FromConfiguration, context: null);
             claims.Count().Should().Be(1);
             claims.First().FindFirst(ClaimTypes.NameIdentifier).Value.Should().Be("SomeUser");
         }
@@ -1105,7 +1105,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             options.SPOptions.ServiceCertificates.Add(new ServiceCertificate { Certificate = SignedXmlHelper.TestCert });
             options.SPOptions.ServiceCertificates.Add(new ServiceCertificate { Certificate = SignedXmlHelper.TestCert2 });
 
-            var claims = Saml2Response.Read(signedResponse).GetClaims(options);
+            var claims = Saml2Response.Read(signedResponse).GetClaims(options, context: null);
             claims.Count().Should().Be(1);
             claims.First().FindFirst(ClaimTypes.NameIdentifier).Value.Should().Be("UserIDInsideEncryptedAssertion");
         }
@@ -1141,7 +1141,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var options = StubFactory.CreateOptions();
             options.SPOptions.ServiceCertificates.Add(new ServiceCertificate { Certificate = SignedXmlHelper.TestCert });
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options, context: null);
 
             a.Should().Throw<Saml2ResponseFailedValidationException>()
                 .WithMessage("Encrypted Assertion(s) could not be decrypted using the configured Service Certificate(s).");
@@ -1177,7 +1177,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var encryptedAssertion = SignedXmlHelper.EncryptAssertion(signedAssertion, useOaep: true);
             var responseWithAssertion = string.Format(response, encryptedAssertion);
 
-            var claims = Saml2Response.Read(responseWithAssertion).GetClaims(Options.FromConfiguration);
+            var claims = Saml2Response.Read(responseWithAssertion).GetClaims(Options.FromConfiguration, context: null);
             claims.Count().Should().Be(1);
             claims.First().FindFirst(ClaimTypes.NameIdentifier).Value.Should().Be("SomeUser");
         }
@@ -1227,7 +1227,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             }
             var responseWithAssertion = string.Format(response, assertionXml);
 
-			var claims = Saml2Response.Read(responseWithAssertion).GetClaims(Options.FromConfiguration);
+			var claims = Saml2Response.Read(responseWithAssertion).GetClaims(Options.FromConfiguration, context: null);
             claims.Count().Should().Be(1);
             claims.First().FindFirst(ClaimTypes.NameIdentifier).Value.Should().Be("WIFUser");
         }
@@ -1261,7 +1261,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var encryptedAssertion = SignedXmlHelper.EncryptAssertion(assertion);
             var responseWithAssertion = string.Format(response, encryptedAssertion);
 
-            Action a = () => Saml2Response.Read(responseWithAssertion).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(responseWithAssertion).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<Saml2ResponseFailedValidationException>()
                 .WithMessage("The SAML Response is not signed and contains unsigned Assertions. Response cannot be trusted.");
@@ -1298,7 +1298,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var encryptedAssertion = SignedXmlHelper.EncryptAssertion(tamperedAssertion);
             var responseWithAssertion = string.Format(response, encryptedAssertion);
 
-            Action a = () => Saml2Response.Read(responseWithAssertion).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(responseWithAssertion).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<InvalidSignatureException>()
                 .WithMessage("Signature didn't verify. Have the contents been tampered with?");
@@ -1334,7 +1334,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var options = StubFactory.CreateOptions();
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options, context: null);
             a.Should().Throw<Saml2ResponseFailedValidationException>();
         }
 
@@ -1381,7 +1381,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var r = Saml2Response.Read(SignedXmlHelper.SignXml(response));
 
-            r.GetClaims(StubFactory.CreateOptions())
+            r.GetClaims(StubFactory.CreateOptions(), context: null)
                 .Should().BeEquivalentTo(expected, opt => opt.IgnoringCyclicReferences());
         }
 
@@ -1423,7 +1423,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var r = Saml2Response.Read(SignedXmlHelper.SignXml(response));
 
-            var claims = r.GetClaims(options).Single();
+            var claims = r.GetClaims(options, context: null).Single();
 
             // Not same object as we're reading it twice.
             claims.BootstrapContext.Should().BeEquivalentTo(expected);
@@ -1463,7 +1463,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var options = StubFactory.CreateOptions();
 
-            subject.Invoking(s => s.GetClaims(options))
+            subject.Invoking(s => s.GetClaims(options, context: null))
                 .Should().Throw<SecurityTokenInvalidAudienceException>();
 		}
 
@@ -1508,7 +1508,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
                 xml.OuterXml.Should().Contain("https://example.com/wrong/audience");
             };
 
-            subject.Invoking(s => s.GetClaims(options)).Should().NotThrow();
+            subject.Invoking(s => s.GetClaims(options, context: null)).Should().NotThrow();
         }
 
         [TestMethod]
@@ -1538,7 +1538,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             response = SignedXmlHelper.SignXml(response);
             var r = Saml2Response.Read(response);
 
-            Action a = () => r.GetClaims(Options.FromConfiguration);
+            Action a = () => r.GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<SecurityTokenExpiredException>();
         }
@@ -1564,7 +1564,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var response = Saml2Response.Read(responseXML, new Saml2Id("abc123"));
 
-            Action a = () => response.GetClaims(Options.FromConfiguration);
+            Action a = () => response.GetClaims(Options.FromConfiguration, context: null);
             a.Should().NotThrow();
         }
 
@@ -1586,7 +1586,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var response = Saml2Response.Read(responseXML);
 
-            Action a = () => response.GetClaims(Options.FromConfiguration);
+            Action a = () => response.GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<Saml2ResponseFailedValidationException>()
                 .WithMessage("Unsolicited responses are not allowed for idp \"https://idp2.example.com\".");
@@ -1614,7 +1614,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var response = Saml2Response.Read(responseXML);
 
-            Action a = () => response.GetClaims(Options.FromConfiguration);
+            Action a = () => response.GetClaims(Options.FromConfiguration, context: null);
             a.Should().NotThrow();
         }
 
@@ -1649,7 +1649,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var subject = Saml2Response.Read(responseXML, new Saml2Id("somevalue"));
 
-            Action a = () => subject.GetClaims(StubFactory.CreateOptions());
+            Action a = () => subject.GetClaims(StubFactory.CreateOptions(), context: null);
 
             a.Should().Throw<Saml2ResponseFailedValidationException>()
                 .WithMessage("InResponseTo Id \"anothervalue\" in received response does not match Id \"somevalue\" of the sent request.");
@@ -1686,7 +1686,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var subject = Saml2Response.Read(responseXML, null);
 
-            Action a = () => subject.GetClaims(StubFactory.CreateOptions());
+            Action a = () => subject.GetClaims(StubFactory.CreateOptions(), context: null);
 
             a.Should().Throw<UnexpectedInResponseToException>()
                 .WithMessage("*unexpected InResponseTo \"InResponseTo\"*");
@@ -1742,7 +1742,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             };
 
             // Should not throw
-            subject.GetClaims(options);
+            subject.GetClaims(options, context: null);
 
             capturedResponse.Should().BeSameAs(subject);
             claimsIdentities.Single().FindFirst(ClaimTypes.NameIdentifier).Value.Should().Be("SomeUser");
@@ -1778,7 +1778,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var subject = Saml2Response.Read(responseXML, new Saml2Id("ExpectedId"));
 
-            Action a = () => subject.GetClaims(StubFactory.CreateOptions());
+            Action a = () => subject.GetClaims(StubFactory.CreateOptions(), context: null);
 
             a.Should().Throw<Saml2ResponseFailedValidationException>()
 				.WithMessage(
@@ -1842,7 +1842,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var subject = Saml2Response.Read(responseXML, new Saml2Id("ExpectedId"), options);
 
-            Action a = () => subject.GetClaims(StubFactory.CreateOptions());
+            Action a = () => subject.GetClaims(StubFactory.CreateOptions(), context: null);
 
             a.Should().Throw<Saml2ResponseFailedValidationException>()
                 .WithMessage("Expected message to contain InResponseTo \"ExpectedId\", but found none*");
@@ -1871,7 +1871,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             Action a = () =>
             {
-                response.GetClaims(Options.FromConfiguration);
+                response.GetClaims(Options.FromConfiguration, context: null);
             };
 
             a.Should().Throw<InvalidSignatureException>()
@@ -1912,7 +1912,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             Action a = () =>
             {
-                response.GetClaims(options);
+                response.GetClaims(options, context: null);
             };
 
             a.Should().Throw<InvalidSignatureException>()
@@ -1945,11 +1945,11 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             response = SignedXmlHelper.SignXml(response);
             var r1 = Saml2Response.Read(response);
-            r1.GetClaims(Options.FromConfiguration);
+            r1.GetClaims(Options.FromConfiguration, context: null);
 
             var r2 = Saml2Response.Read(response);
 
-            Action a = () => r2.GetClaims(Options.FromConfiguration);
+            Action a = () => r2.GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<SecurityTokenReplayDetectedException>();
         }
@@ -1981,11 +1981,11 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             response = SignedXmlHelper.SignXml(response);
             var r1 = Saml2Response.Read(response);
             var options = StubFactory.CreateOptions();
-            r1.GetClaims(options);
+            r1.GetClaims(options, context: null);
 
             var r2 = Saml2Response.Read(response);
 
-            Action a = () => r2.GetClaims(options);
+            Action a = () => r2.GetClaims(options, context: null);
 
             a.Should().Throw<SecurityTokenReplayDetectedException>();
         }
@@ -2017,12 +2017,12 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             response = SignedXmlHelper.SignXml(response);
             var r1 = Saml2Response.Read(response);
             var options1 = StubFactory.CreateOptions();
-            r1.GetClaims(options1);
+            r1.GetClaims(options1, context: null);
 
             var r2 = Saml2Response.Read(response);
 
             var options2 = StubFactory.CreateOptions();
-            Action a = () => r2.GetClaims(options2);
+            Action a = () => r2.GetClaims(options2, context: null);
 
             a.Should().NotThrow();
         }
@@ -2055,7 +2055,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var subject = Saml2Response.Read(xml);
 
-            Action a = () => subject.GetClaims(Options.FromConfiguration);
+            Action a = () => subject.GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<UnsuccessfulSamlOperationException>()
                 .WithMessage("The Saml2Response must have status success to extract claims.\n*Status Code: Requester*")
@@ -2084,7 +2084,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var subject = Saml2Response.Read(xml);
 
-            Action a = () => subject.GetClaims(Options.FromConfiguration);
+            Action a = () => subject.GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<UnsuccessfulSamlOperationException>()
                 .WithMessage("The Saml2Response must have status success to extract claims.*Status Code: Responder*Message: A status message*RequestDenied")
@@ -2142,7 +2142,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var tamperedXml = xmlDoc.OuterXml;
 
-            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<CryptographicException>()
                 .WithMessage("Malformed element Signature.");
@@ -2163,7 +2163,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             response.SetAttribute("ID", "_xsw2_explot_response_deadbeef");
 
             var tamperedXml = xmlDoc.OuterXml;
-            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<InvalidSignatureException>()
                 .WithMessage("Incorrect reference on Xml signature. The reference must be to the root element of the element containing the signature.");
@@ -2182,7 +2182,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             xmlDoc.DocumentElement.InsertBefore(clonedAssertion, assertion);
 
             var tamperedXml = xmlDoc.OuterXml;
-            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<InvalidSignatureException>()
                 .WithMessage("Signature didn't verify. Have the contents been tampered with?");
@@ -2202,7 +2202,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             clonedAssertion.AppendChild(assertion);
 
             var tamperedXml = xmlDoc.OuterXml;
-            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<InvalidSignatureException>()
                 .WithMessage("Signature didn't verify. Have the contents been tampered with?");
@@ -2221,7 +2221,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             assertion.SetAttribute("ID", "_xsw5_explot_response_deadbeef");
 
             var tamperedXml = xmlDoc.OuterXml;
-            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<InvalidSignatureException>()
                 .WithMessage("Signature didn't verify. Have the contents been tampered with?");
@@ -2241,7 +2241,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             assertion.SetAttribute("ID", "_xsw6_explot_response_deadbeef");
 
             var tamperedXml = xmlDoc.OuterXml;
-            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<InvalidSignatureException>()
                 .WithMessage("Signature didn't verify. Have the contents been tampered with?");
@@ -2261,7 +2261,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             extensions.AppendChild(clonedAssertion);
 
             var tamperedXml = xmlDoc.OuterXml;
-            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<InvalidSignatureException>()
                 .WithMessage("Signature didn't verify. Have the contents been tampered with?");
@@ -2282,7 +2282,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             xmlObject.AppendChild(clonedAssertion);
 
             var tamperedXml = xmlDoc.OuterXml;
-            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration);
+            Action a = () => Saml2Response.Read(tamperedXml).GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<InvalidSignatureException>()
                 .WithMessage("Signature didn't verify. Have the contents been tampered with?");
@@ -2318,7 +2318,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var subject = Saml2Response.Read(xml);
 
-            Action a = () => subject.GetClaims(Options.FromConfiguration);
+            Action a = () => subject.GetClaims(Options.FromConfiguration, context: null);
 
             a.Should().Throw<UnsuccessfulSamlOperationException>()
                 .WithMessage("The Saml2Response must have status success to extract claims.*Status Code: Requester*Message: A status message*")
@@ -2337,7 +2337,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             var response = new Saml2Response(issuer, null, null, null, identity);
 
             response.Issuer.Should().Be(issuer);
-            response.GetClaims(Options.FromConfiguration)
+            response.GetClaims(Options.FromConfiguration, context: null)
                 .Single()
                 .Should().BeEquivalentTo(identity);
         }
@@ -2513,7 +2513,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             idp.SigningKeys.AddConfiguredKey(SignedXmlHelper.TestKeySignOnly);
             options.IdentityProviders.Add(idp);
 
-            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options);
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(options, context: null);
             a.Should().NotThrow();
         }
 
@@ -2548,7 +2548,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             responseXml = SignedXmlHelper.SignXml(responseXml);
 
             Saml2Response.Read(responseXml).Invoking(
-                r => r.GetClaims(options))
+                r => r.GetClaims(options, context: null))
                 .Should().Throw<InvalidSignatureException>()
                 .And.Message.Should().Be("The signature was valid, but the verification of the certificate failed. Is it expired or revoked? Are you sure you really want to enable ValidateCertificates (it's normally not needed)?");
         }
@@ -2582,7 +2582,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             responseXml = SignedXmlHelper.SignXml(responseXml);
 
             Saml2Response.Read(responseXml).Invoking(
-                r => r.GetClaims(options))
+                r => r.GetClaims(options, context: null))
                 .Should().Throw<Saml2Exception>()
                 .WithMessage("*subject confirmation*bearer*");
         }
@@ -2615,7 +2615,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             responseXml = SignedXmlHelper.SignXml(responseXml);
 
             Saml2Response.Read(responseXml).Invoking(
-                r => r.GetClaims(options))
+                r => r.GetClaims(options, context: null))
                 .Should().Throw<Saml2ResponseFailedValidationException>()
                 .WithMessage("*No subject confirmation*");
         }
@@ -2666,7 +2666,7 @@ namespace Sustainsys.Saml2.Tests.Saml2P
 
             var subject = Saml2Response.Read(SignedXmlHelper.SignXml(response));
 
-            subject.GetClaims(StubFactory.CreateOptions());
+            subject.GetClaims(StubFactory.CreateOptions(), context: null);
 
             subject.SessionNotOnOrAfter.Should().Be(new DateTime(2050, 1, 1, 0, 0, 0, DateTimeKind.Utc));
         }

--- a/Tests/Tests.Shared/WebSSO/AcsCommandTests.cs
+++ b/Tests/Tests.Shared/WebSSO/AcsCommandTests.cs
@@ -527,10 +527,12 @@ namespace Sustainsys.Saml2.Tests.WebSso
                 </saml2:Assertion>
             </saml2p:Response>";
 
+            var context = new object(); // HttpContext
             var formValue = Convert.ToBase64String(Encoding.UTF8.GetBytes(
                 SignedXmlHelper.SignXml(response)));
 
-            var requestData = new HttpRequestData(
+            var requestData = new HttpRequestData<object>(
+                context,
                 "POST",
                 new Uri("http://localhost"),
                 "/ModulePath",
@@ -557,8 +559,9 @@ namespace Sustainsys.Saml2.Tests.WebSso
             };
 
             var getIdentityProviderCalled = false;
-            options.Notifications.GetIdentityProvider = (idpEntityId, relayData, opt) =>
+            options.Notifications.GetIdentityProvider = (ctx, idpEntityId, relayData, opt) =>
             {
+                ctx.Should().BeSameAs(context);
                 idpEntityId.Id.Should().Be("https://idp.example.com");
                 relayData.Should().BeNull();
                 getIdentityProviderCalled = true;
@@ -707,6 +710,7 @@ namespace Sustainsys.Saml2.Tests.WebSso
                 </saml2:Assertion>
             </saml2p:Response>";
 
+            var context = new object(); // HttpContext
             var formValue = Convert.ToBase64String(Encoding.UTF8.GetBytes(
                 SignedXmlHelper.SignXml(response)));
 
@@ -715,7 +719,8 @@ namespace Sustainsys.Saml2.Tests.WebSso
                 { "key", "value" }
             };
 
-            var requestData = new HttpRequestData(
+            var requestData = new HttpRequestData<object>(
+                context,
                 "POST",
                 new Uri("http://localhost"),
                 "/ModulePath",
@@ -731,8 +736,9 @@ namespace Sustainsys.Saml2.Tests.WebSso
 
             var options = StubFactory.CreateOptions();
 
-            options.Notifications.GetIdentityProvider = (idpEntityId, rd, opt) =>
+            options.Notifications.GetIdentityProvider = (ctx, idpEntityId, rd, opt) =>
             {
+                ctx.Should().BeSameAs(context);
                 idpEntityId.Id.Should().Be("https://other.idp.example.com");
                 rd["key"].Should().Be("value");
 

--- a/Tests/Tests.Shared/WebSSO/Saml2ArtifactBindingTests.cs
+++ b/Tests/Tests.Shared/WebSSO/Saml2ArtifactBindingTests.cs
@@ -83,6 +83,7 @@ namespace Sustainsys.Saml2.Tests.WebSso
         [TestMethod]
         public void Saml2ArtifactBinding_Unbind_FromGetUsesIdpFromNotification()
         {
+            var context = new object(); // HttpContext
             var issuer = new EntityId("https://idp.example.com");
             var artifact = Uri.EscapeDataString(
                 Convert.ToBase64String(
@@ -95,7 +96,8 @@ namespace Sustainsys.Saml2.Tests.WebSso
                 { "key", "value" }
             };
 
-            var r = new HttpRequestData(
+            var r = new HttpRequestData<object>(
+                context,
                 "GET",
                 new Uri($"http://example.com/path/acs?SAMLart={artifact}&RelayState={relayState}"),
                 null,
@@ -108,8 +110,9 @@ namespace Sustainsys.Saml2.Tests.WebSso
             options.IdentityProviders.Remove(idp.EntityId);
 
             var getIdentityProviderCalled = false;
-            options.Notifications.GetIdentityProvider = (ei, rd, opt) =>
+            options.Notifications.GetIdentityProvider = (ctx, ei, rd, opt) =>
             {
+                ctx.Should().BeSameAs(context);
                 getIdentityProviderCalled = true;
                 rd["key"].Should().Be("value");
                 return idp;

--- a/Tests/Tests.Shared/WebSSO/SignInCommandTests.cs
+++ b/Tests/Tests.Shared/WebSSO/SignInCommandTests.cs
@@ -214,20 +214,25 @@ namespace Sustainsys.Saml2.Tests.WebSso
         [TestMethod]
         public void SignInCommand_Run_Calls_Notifications()
         {
+            var context = new object(); // HttpContext
             var options = StubFactory.CreateOptions();
             var idp = options.IdentityProviders.Default;
             var relayData = new Dictionary<string, string>();
             options.SPOptions.DiscoveryServiceUrl = null;
            
-            var request = new HttpRequestData("GET",
+            var request = new HttpRequestData<object>(
+                context,
+                "GET",
                 new Uri("http://sp.example.com"));
 
             var selectedIdpCalled = false;
             options.Notifications.SelectIdentityProvider =
-                (ei, r) =>
+                (ctx, ei, r, o) =>
             {
+                ctx.Should().BeSameAs(context);
                 ei.Should().BeSameAs(idp.EntityId);
                 r.Should().BeSameAs(relayData);
+                o.Should().BeSameAs(options);
                 selectedIdpCalled = true;
                 return null;
             };
@@ -275,8 +280,9 @@ namespace Sustainsys.Saml2.Tests.WebSso
             var request = new HttpRequestData("GET",
                 new Uri("http://sp.example.com"));
 
-            options.Notifications.SelectIdentityProvider = (ei, r) =>
+            options.Notifications.SelectIdentityProvider = (ctx, ei, r, o) =>
             {
+                ctx.Should().BeNull();
                 return idp;
             };
 


### PR DESCRIPTION
This addresses Sustainsys/Saml2#896.

Given that the core library is still targeting .NET Standard, we can't introduce .NET Core's `HttpContext` yet. As a bridge to that point, this solution derives a class with a generic parameter from the current `HttpRequestData`, which has a new object property to hold the context. This is a similar approach to `IEnumerator<T>` vs. the object-based `IEnumerator`. Although in that case, the `Current` property is suppressed with the `new` modifier, whereas this solution uses a virtual property with a second typed property in the derived class, so that the instance data can be shared instead of being duplicated.

The new filename uses a name based on the .NET team's naming conventions. Happy to change it.

The notification handler signatures have been modified to take the new context object. Implementors will need to cast to their target-specific type (i.e., `HttpContext` on Core or `HttpRequestBase` on Framework). This can be replaced with a typed parameter if/when this library becomes Core only.

Only two notifications were updated--those required to support loading `IdentityProvider`s from a data source. As part of this, `IOptions` was added to `SelectIdentityProvider`, which makes the signature the same as `GetIdentityProvider `.

`GetClaims` was modified to take a context argument. The reason it's not defaulted to null is because that would make it easy to mistakenly not provide that parameter in the library itself. The cost is that existing tests now have an extra null argument.