### PR TITLE
Added support for detecting .NET 5.0+ as .NET Core

### DIFF
--- a/Sustainsys.Saml2.Metadata/Helpers/EnvironmentHelpers.cs
+++ b/Sustainsys.Saml2.Metadata/Helpers/EnvironmentHelpers.cs
@@ -7,11 +7,11 @@ namespace Sustainsys.Saml2.Metadata.Helpers
     {
         public static bool IsNetCore =>
 #if NETSTANDARD2_0
-            RuntimeInformation.FrameworkDescription.
-            StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
-
+        // To support .NET 5.0 and up, specifically check if this is not .NET Framework.
+        // Since .NET 5.0, the description no longer starts with ".NET Core", but simply ".NET". 
+        !RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 #else
-        // If not netstandard, then it is one of the .NET Framework targets. And
+        // If not netstandard, then it is one of the .NET Framework targets. And 
         // obviously not running on core.
         false;
 #endif

--- a/Sustainsys.Saml2/Internal/EnvironmentHelpers.cs
+++ b/Sustainsys.Saml2/Internal/EnvironmentHelpers.cs
@@ -5,10 +5,11 @@ namespace Sustainsys.Saml2.Internal
 {
 	public class EnvironmentHelpers
     {
-		public static bool IsNetCore =>
+        public static bool IsNetCore =>
 #if NETSTANDARD2_0
-            RuntimeInformation.FrameworkDescription.
-			StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
+        // To support .NET 5.0 and up, specifically check if this is not .NET Framework.
+        // Since .NET 5.0, the description no longer starts with ".NET Core", but simply ".NET". 
+        !RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 #else
         // If not netstandard, then it is one of the .NET Framework targets. And 
         // obviously not running on core.


### PR DESCRIPTION
Since .NET 5.0, the version string in `RuntimeInformation.FrameworkDescription` no longer starts with `.NET Core`, but rather `.NET <version number>`. This fix inverts the .NET Core check, by checking that the version string does not start with `.NET Framework`. This way, future .NET (Core) versions will also be detected correctly.  

See https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription?view=net-5.0

Resolves #1316, Resolves #1252