### PR TITLE
Improve logout information

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/PostConfigureSaml2Options.cs
+++ b/Sustainsys.Saml2.AspNetCore2/PostConfigureSaml2Options.cs
@@ -23,7 +23,7 @@ namespace Sustainsys.Saml2.AspNetCore2
         /// <summary>
         /// Ctor
         /// </summary>
-        /// <param name="loggerFactory">Logger factory to use to hook up Saml2 loggin.</param>
+        /// <param name="loggerFactory">Logger factory to use to hook up Saml2 logging.</param>
         /// <param name="authOptions">Authentication options, to look up Default Sign In schema</param>
         public PostConfigureSaml2Options(
             ILoggerFactory loggerFactory,
@@ -45,14 +45,18 @@ namespace Sustainsys.Saml2.AspNetCore2
                 throw new ArgumentNullException(nameof(options));
             }
 
-            if(loggerFactory != null)
+            // Logger may have been set in the options already. In that case keep it as it is.
+            if (options.SPOptions.Logger == null)
             {
-                options.SPOptions.Logger = new AspNetCoreLoggerAdapter(
-                    loggerFactory.CreateLogger<Saml2Handler>());
-            }
-            else
-            {
-                options.SPOptions.Logger = new NullLoggerAdapter();
+                if (loggerFactory != null)
+                {
+                    options.SPOptions.Logger = new AspNetCoreLoggerAdapter(
+                        loggerFactory.CreateLogger<Saml2Handler>());
+                }
+                else
+                {
+                    options.SPOptions.Logger = new NullLoggerAdapter();
+                }
             }
             options.SPOptions.Logger.WriteVerbose("Saml2 logging enabled.");
 

--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -291,6 +291,10 @@ namespace Sustainsys.Saml2.WebSso
             var result = Saml2Binding.Get(idp.SingleLogoutServiceBinding).Bind(
                 response, options.SPOptions.Logger, options.Notifications.LogoutResponseXmlCreated);
             result.TerminateLocalSession = true;
+
+            // 'request' contains details about the logout command. We return that details to whoever is listening to the notifications.
+            result.Content = Newtonsoft.Json.JsonConvert.SerializeObject(request);
+
             return result;
         }
 

--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -292,8 +292,11 @@ namespace Sustainsys.Saml2.WebSso
                 response, options.SPOptions.Logger, options.Notifications.LogoutResponseXmlCreated);
             result.TerminateLocalSession = true;
 
-            // 'request' contains details about the logout command. We return that details to whoever is listening to the notifications.
-            result.Content = Newtonsoft.Json.JsonConvert.SerializeObject(request);
+            if (result.Content == null)
+            {
+                // 'request' contains details about the logout command. We return that details to whoever is listening to the notifications.
+                result.Content = Newtonsoft.Json.JsonConvert.SerializeObject(request);
+            }
 
             return result;
         }

--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -87,10 +87,12 @@ namespace Sustainsys.Saml2.WebSso
                 switch (unbindResult.Data.LocalName)
                 {
                     case "LogoutRequest":
+                        options.SPOptions.Logger.WriteVerbose("Logout triggered (LogoutRequest)");
                         VerifyMessageIsSigned(unbindResult, options);
                         commandResult = HandleRequest(unbindResult, request, options);
                         break;
                     case "LogoutResponse":
+                        options.SPOptions.Logger.WriteVerbose("Logout triggered (LogoutResponse)");
                         if (!options.SPOptions.Compatibility.AcceptUnsignedLogoutResponses)
                         {
                             VerifyMessageIsSigned(unbindResult, options);
@@ -105,6 +107,7 @@ namespace Sustainsys.Saml2.WebSso
             }
             else
             {
+                options.SPOptions.Logger.WriteVerbose("Logout triggered (binding==NULL)");
                 commandResult = InitiateLogout(request, returnUrl, options, true);
             }
             options.Notifications.LogoutCommandResultCreated(commandResult);
@@ -282,8 +285,8 @@ namespace Sustainsys.Saml2.WebSso
 
             options.Notifications.LogoutResponseCreated(response, request, httpRequest.User, idp);
 
-            options.SPOptions.Logger.WriteInformation("Got a logout request " + request.Id
-                + ", responding with logout response " + response.Id);
+            options.SPOptions.Logger.WriteInformation("Got a logout request " + request.Id.Value
+                + ", responding with logout response " + response.Id.Value);
 
             var result = Saml2Binding.Get(idp.SingleLogoutServiceBinding).Bind(
                 response, options.SPOptions.Logger, options.Notifications.LogoutResponseXmlCreated);
@@ -321,7 +324,7 @@ namespace Sustainsys.Saml2.WebSso
             }
             commandResult.Location = storedRequestState?.ReturnUrl ?? returnUrl;
 
-            options.SPOptions.Logger.WriteInformation("Received logout response " + logoutResponse.Id
+            options.SPOptions.Logger.WriteInformation("Received logout response " + logoutResponse.Id.Value
                 + ", redirecting to " + commandResult.Location);
 
             return commandResult;

--- a/Tests/Tests.Shared/WebSSO/LogoutCommandTests.cs
+++ b/Tests/Tests.Shared/WebSSO/LogoutCommandTests.cs
@@ -569,12 +569,13 @@ namespace Sustainsys.Saml2.Tests.WebSso
                 HttpStatusCode = HttpStatusCode.SeeOther,
                 TerminateLocalSession = true
                 // Deliberately not comparing Location
+                // Deliberately not comparing Content
             };
 
             HttpUtility.ParseQueryString(actual.Location.Query)["Signature"]
                 .Should().NotBeNull("LogoutResponse should be signed");
 
-            actual.Should().BeEquivalentTo(expected, opt => opt.Excluding(cr => cr.Location));
+            actual.Should().BeEquivalentTo(expected, opt => opt.Excluding(cr => cr.Location).Excluding(cr => cr.Content));
             actual.Should().BeSameAs(notifiedCommandResult);
             logoutResponse.InResponseTo.Value.Should().Be(request.Id.Value);
             xmlCreatedCalled.Should().BeTrue();


### PR DESCRIPTION
I have improved the logout handling slightly.  I first improved the logging to be able to trace what is going on. Then I extended the information that is sent to the listener of the logout notification.

1. First of all, when a custom logger is set in the clients code like this:

       authenticationBuilder.AddSaml2(authenticationScheme, options =>
       {
           options.SPOptions = new SPOptions
          {
              ...
              Logger = (ILoggerAdapter)logger
          };
       };
That logger got replaced by the default logger, so I introduced a check in for a custom logger before the default logger is set. That happens in the `PostConfigureSaml2Options.cs`

2. I added some verbose logging in `LogOutCommand.cs`.

3. The information sent in the `options.Notifications.LogoutCommandResultCreated` was very limited, only `Location` was set, so I added some details about the context of the logout to the `Content` member. I also adjusted the Unit Test to account for this change.