### PR TITLE
Parse LogoutResponse XML values into Saml2LogoutResponse

### DIFF
--- a/Sustainsys.Saml2/SAML2P/Saml2LogoutResponse.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2LogoutResponse.cs
@@ -1,11 +1,8 @@
-﻿using Sustainsys.Saml2.Internal;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using System.Xml;
 using System.Xml.Linq;
+
+using Sustainsys.Saml2.Internal;
 
 namespace Sustainsys.Saml2.Saml2P
 {
@@ -75,10 +72,10 @@ namespace Sustainsys.Saml2.Saml2P
         }
 
         /// <summary>
-        /// Load values into 
+        /// Load values into Saml2LogoutResponse from passed xml element
         /// </summary>
-        /// <param name="xml"></param>
-        /// <returns></returns>
+        /// <param name="xml">XmlElement containing a LogoutResponse</param>
+        /// <returns>Saml2LogoutResponse</returns>
         public static Saml2LogoutResponse FromXml(XmlElement xml)
         {
             if(xml == null)
@@ -90,7 +87,11 @@ namespace Sustainsys.Saml2.Saml2P
                 xml["Status", Saml2Namespaces.Saml2PName]
                 ["StatusCode", Saml2Namespaces.Saml2PName]
                 .GetAttribute("Value"));
-            return new Saml2LogoutResponse(status);
+
+            var response = new Saml2LogoutResponse(status);
+            response.ReadBaseProperties(xml);
+
+            return response;
         }
     }
 }

--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -320,7 +320,7 @@ namespace Sustainsys.Saml2.WebSso
             }
             commandResult.Location = storedRequestState?.ReturnUrl ?? returnUrl;
 
-            options.SPOptions.Logger.WriteInformation("Received logout response " + logoutResponse.Id
+            options.SPOptions.Logger.WriteInformation("Received logout response " + logoutResponse.Id.Value
                 + ", redirecting to " + commandResult.Location);
 
             return commandResult;

--- a/Tests/Tests.Shared/Saml2P/Saml2LogoutResponseTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2LogoutResponseTests.cs
@@ -94,5 +94,41 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             a.Should().Throw<ArgumentNullException>()
                 .And.ParamName.Should().Be("xml");
         }
+
+        [TestMethod]
+        public void Saml2LogoutResponse_FromXml()
+        {
+            var expected = new Saml2LogoutResponse(Saml2StatusCode.Success)
+            {
+                DestinationUrl = new Uri("https://IdentityProvider.com/Logout"),
+                Id = new Saml2Id(),
+                InResponseTo = new Saml2Id(),
+                IssueInstant = new DateTime(2021, 11, 06, 1, 2, 3, 0, DateTimeKind.Utc),
+                Issuer = new EntityId("https://ServiceProvider.com/SAML"),
+            };
+
+            var inputXml = $@"<samlp:LogoutResponse xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol""
+                    xmlns=""urn:oasis:names:tc:SAML:2.0:assertion""
+                    ID=""{expected.Id.Value}""
+                    InResponseTo=""{expected.InResponseTo.Value}""
+                    IssueInstant=""{expected.IssueInstant.ToSaml2DateTimeString()}"" Version=""2.0""
+                    Destination=""{expected.DestinationUrl}"">
+                    <Issuer>{expected.Issuer.Id}</Issuer>
+                    <samlp:Status>
+                        <samlp:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success""/>
+                    </samlp:Status>
+                </samlp:LogoutResponse>";
+
+            var doc = new XmlDocument();
+            doc.LoadXml(inputXml);
+            var actual = Saml2LogoutResponse.FromXml(doc.DocumentElement);
+
+            actual.Id.Value.Should().Be(expected.Id.Value);
+            actual.DestinationUrl.Should().Be(expected.DestinationUrl);
+            actual.InResponseTo.Value.Should().Be(expected.InResponseTo.Value);
+            actual.IssueInstant.Should().Be(expected.IssueInstant);
+            actual.Issuer.Id.Should().Be(expected.Issuer.Id);
+            actual.Status.Should().Be(expected.Status);
+        }
     }
 }


### PR DESCRIPTION
In order to comply with the Danish NemLog-in logging policy, one has to log a long list of SAML2 properties. I’ve been able to get most log properties by hooking into the notifications at strategically picked points. However, I ran into a problem with logout responses, seems like SustainSys.Saml2 only parsed the status value from a LogoutResponse. I wanted the ID and InResponseTo attributes as well. 

Seemed straight forward enough to add deserialisation of the remaining attributes to Saml2LogoutResponse.FromXml().
