### PR TITLE
Support .NET 6

### DIFF
--- a/Sustainsys.Saml2/Internal/EnvironmentHelpers.cs
+++ b/Sustainsys.Saml2/Internal/EnvironmentHelpers.cs
@@ -6,7 +6,7 @@ namespace Sustainsys.Saml2.Internal
 	public class EnvironmentHelpers
     {
         public static bool IsNetCore =>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0 || NET6_0
         // To support .NET 5.0 and up, specifically check if this is not .NET Framework.
         // Since .NET 5.0, the description no longer starts with ".NET Core", but simply ".NET". 
         !RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
Fix Unable to cast object of type 'System.Security.Cryptography.RSACng' to type 'System.Security.Cryptography.RSACryptoServiceProvider "Sustainsys.Saml2" for .NET 6.0