### PR TITLE
Read IgnoreAuthenticationContextInResponse from config

### DIFF
--- a/Sustainsys.Saml2/Configuration/Compatibility.cs
+++ b/Sustainsys.Saml2/Configuration/Compatibility.cs
@@ -33,6 +33,8 @@ namespace Sustainsys.Saml2.Configuration
                 configElement.UnpackEntitiesDescriptorInIdentityProviderMetadata;
             DisableLogoutStateCookie = configElement.DisableLogoutStateCookie;
             IgnoreMissingInResponseTo = configElement.IgnoreMissingInResponseTo;
+            IgnoreAuthenticationContextInResponse =
+                configElement.IgnoreAuthenticationContextInResponse;
         }
 
         /// <summary>

--- a/Sustainsys.Saml2/Configuration/CompatibilityElement.cs
+++ b/Sustainsys.Saml2/Configuration/CompatibilityElement.cs
@@ -85,5 +85,27 @@ namespace Sustainsys.Saml2.Configuration
                 base[ignoreMissingInResponseTo] = value;
             }
         }
+
+        const string ignoreAuthenticationContextInResponse
+            = nameof(ignoreAuthenticationContextInResponse);
+
+        /// <summary>
+        /// Do not read the AuthnContext element in Saml2Response. If you do not need
+        /// these values to be present as claims in the generated identity, using this
+        /// option can prevent XML format errors (System.Xml.XmlException:
+        /// ID0013: The value must be an absolute URI), when value cannot parse as absolute URI.
+        /// </summary>
+        [ConfigurationProperty(ignoreAuthenticationContextInResponse, IsRequired = false)]
+        public bool IgnoreAuthenticationContextInResponse
+        {
+            get
+            {
+                return (bool)base[ignoreAuthenticationContextInResponse];
+            }
+            set
+            {
+                base[ignoreAuthenticationContextInResponse] = value;
+            }
+        }
     }
 }

--- a/Tests/Tests.Shared/Configuration/SPOptionsTests.cs
+++ b/Tests/Tests.Shared/Configuration/SPOptionsTests.cs
@@ -28,6 +28,7 @@ namespace Sustainsys.Saml2.Tests.Configuration
                 SustainsysSaml2Section.Current.Compatibility.UnpackEntitiesDescriptorInIdentityProviderMetadata = false;
                 SustainsysSaml2Section.Current.Compatibility.DisableLogoutStateCookie = false;
                 SustainsysSaml2Section.Current.Compatibility.IgnoreMissingInResponseTo = false;
+                SustainsysSaml2Section.Current.Compatibility.IgnoreAuthenticationContextInResponse = false;
                 SustainsysSaml2Section.Current.Compatibility.AllowChange = false;
             }
         }
@@ -67,6 +68,7 @@ namespace Sustainsys.Saml2.Tests.Configuration
             config.Compatibility.UnpackEntitiesDescriptorInIdentityProviderMetadata = true;
             config.Compatibility.DisableLogoutStateCookie = true;
             config.Compatibility.IgnoreMissingInResponseTo = true;
+            config.Compatibility.IgnoreAuthenticationContextInResponse = true;
 
             SPOptions subject = new SPOptions(SustainsysSaml2Section.Current);
             subject.ReturnUrl.Should().Be(config.ReturnUrl);
@@ -88,6 +90,7 @@ namespace Sustainsys.Saml2.Tests.Configuration
             subject.Compatibility.UnpackEntitiesDescriptorInIdentityProviderMetadata.Should().BeTrue();
             subject.Compatibility.DisableLogoutStateCookie.Should().BeTrue();
             subject.Compatibility.IgnoreMissingInResponseTo.Should().BeTrue();
+            subject.Compatibility.IgnoreAuthenticationContextInResponse.Should().BeTrue();
         }
 
         [TestMethod]


### PR DESCRIPTION
Allow `IgnoreAuthenticationContextInResponse` to be read from the config.