### PR TITLE
Optional token replay validation

### DIFF
--- a/Sustainsys.Saml2/Configuration/SPOptions.cs
+++ b/Sustainsys.Saml2/Configuration/SPOptions.cs
@@ -178,7 +178,7 @@ namespace Sustainsys.Saml2.Configuration
 
         /// <summary>
         /// By default, the service provider uses the host, protocol, port and
-        /// application root path from the HTTP request when creating links. 
+        /// application root path from the HTTP request when creating links.
         /// This might not be accurate in reverse proxy or load-balancing
         /// situations. You can override the origin used for link generation
         /// for the entire application using this property. To override per request,
@@ -357,7 +357,7 @@ namespace Sustainsys.Saml2.Configuration
         public SigningBehavior AuthenticateRequestSigningBehavior { get; set; }
 
         /// <summary>
-        /// Signing algorithm for metadata and outbound messages. Can be 
+        /// Signing algorithm for metadata and outbound messages. Can be
         /// overriden for each <see cref="IdentityProvider"/>.
         /// </summary>
         public string OutboundSigningAlgorithm { get; set; }
@@ -409,8 +409,8 @@ namespace Sustainsys.Saml2.Configuration
         public ILoggerAdapter Logger { get; set; }
 
         private ITokenReplayCache tokenReplayCache;
-        public ITokenReplayCache TokenReplayCache 
-        { 
+        public ITokenReplayCache TokenReplayCache
+        {
             get
             {
                 if(tokenReplayCache == null)
@@ -435,7 +435,8 @@ namespace Sustainsys.Saml2.Configuration
             {
                 AuthenticationType = "Federation",
                 RequireSignedTokens = false,
-                ValidateIssuer = false
+                ValidateIssuer = false,
+                ValidateTokenReplay = true,
             }.SetRequireAudience(false); // RequireAudience must be set to false for versions 5.5.0+ that have it.
     }
 }

--- a/Sustainsys.Saml2/SAML2P/Saml2PSecurityTokenHandler.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2PSecurityTokenHandler.cs
@@ -85,10 +85,10 @@ namespace Sustainsys.Saml2.Saml2P
 
 			// Just using the assertion id for token replay. As that is part of the signed value it cannot
 			// be altered by someone replaying the token.
-            if (validationParameters.ValidateTokenReplay)
-            {
-                ValidateTokenReplay(samlToken.Assertion.Conditions.NotOnOrAfter, samlToken.Assertion.Id.Value, validationParameters);
-            }
+			if (validationParameters.ValidateTokenReplay)
+			{
+				ValidateTokenReplay(samlToken.Assertion.Conditions.NotOnOrAfter, samlToken.Assertion.Id.Value, validationParameters);
+			}
 
 			// ValidateIssuerSecurityKey not called - we have our own signature validation.
 

--- a/Sustainsys.Saml2/SAML2P/Saml2PSecurityTokenHandler.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2PSecurityTokenHandler.cs
@@ -31,7 +31,7 @@ namespace Sustainsys.Saml2.Saml2P
 
 		// TODO: needed with Microsoft.identitymodel?
 		/// <summary>
-		/// Process authentication statement from SAML assertion. WIF chokes if the authentication statement 
+		/// Process authentication statement from SAML assertion. WIF chokes if the authentication statement
 		/// contains a DeclarationReference, so we clear this out before calling the base method
 		/// http://referencesource.microsoft.com/#System.IdentityModel/System/IdentityModel/Tokens/Saml2SecurityTokenHandler.cs,1970
 		/// </summary>
@@ -85,7 +85,10 @@ namespace Sustainsys.Saml2.Saml2P
 
 			// Just using the assertion id for token replay. As that is part of the signed value it cannot
 			// be altered by someone replaying the token.
-			ValidateTokenReplay(samlToken.Assertion.Conditions.NotOnOrAfter, samlToken.Assertion.Id.Value, validationParameters);
+            if (validationParameters.ValidateTokenReplay)
+            {
+                ValidateTokenReplay(samlToken.Assertion.Conditions.NotOnOrAfter, samlToken.Assertion.Id.Value, validationParameters);
+            }
 
 			// ValidateIssuerSecurityKey not called - we have our own signature validation.
 

--- a/Sustainsys.Saml2/SAML2P/Saml2Response.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2Response.cs
@@ -604,8 +604,7 @@ namespace Sustainsys.Saml2.Saml2P
             TokenValidationParameters validationParameters = options.SPOptions.TokenValidationParametersTemplate.Clone();
             validationParameters.ValidAudience = options.SPOptions.EntityId.Id;
             validationParameters.TokenReplayCache = options.SPOptions.TokenReplayCache;
-            validationParameters.ValidateTokenReplay = true;
-
+            
             options.Notifications.Unsafe.TokenValidationParametersCreated(validationParameters, idp, XmlElement);
 
 			var handler = options.SPOptions.Saml2PSecurityTokenHandler;


### PR DESCRIPTION
This provides an option to disable Token Replay validation. In some integrations it is required, the defaults are kept unchanged.