### PR TITLE
Added Saml2Subject to AuthnRequest

### DIFF
--- a/Sustainsys.Saml2/SAML2P/Saml2AuthenticationRequest.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2AuthenticationRequest.cs
@@ -10,6 +10,7 @@ using System.Xml.Linq;
 using Sustainsys.Saml2.Configuration;
 using Sustainsys.Saml2.Internal;
 using Sustainsys.Saml2.WebSso;
+using Microsoft.IdentityModel.Tokens.Saml2;
 
 namespace Sustainsys.Saml2.Saml2P
 {
@@ -60,6 +61,7 @@ namespace Sustainsys.Saml2.Saml2P
             }
 
             AddNameIdPolicy(x);
+            AddSubject(x);
 
             if (RequestedAuthnContext != null && RequestedAuthnContext.ClassRef != null)
             {
@@ -112,6 +114,14 @@ namespace Sustainsys.Saml2.Saml2P
             if (Scoping != null)
             {
                 xElement.Add(Scoping.ToXElement());
+            }
+        }
+
+        private void AddSubject(XElement xElement)
+        {
+            if (Subject != null)
+            {
+                xElement.Add(Subject.ToXElement());
             }
         }
 
@@ -213,6 +223,11 @@ namespace Sustainsys.Saml2.Saml2P
         /// NameId policy.
         /// </summary>
         public Saml2NameIdPolicy NameIdPolicy { get; set; }
+        
+        /// <summary>
+        /// Subject.
+        /// </summary>
+        public Saml2Subject Subject { get; set; }
 
         /// <summary>
         /// RequestedAuthnContext.

--- a/Sustainsys.Saml2/WebSSO/SignInCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/SignInCommand.cs
@@ -6,6 +6,7 @@ using System.Net;
 using Sustainsys.Saml2.Configuration;
 using Sustainsys.Saml2.Internal;
 using Sustainsys.Saml2.Metadata;
+using Microsoft.IdentityModel.Tokens.Saml2;
 
 namespace Sustainsys.Saml2.WebSso
 {
@@ -161,6 +162,16 @@ namespace Sustainsys.Saml2.WebSso
             if (!string.IsNullOrWhiteSpace(isPassiveString))
             {
                 authnRequest.IsPassive = bool.Parse(isPassiveString);
+            }
+
+            var subjectString = request.QueryString["Subject"].SingleOrDefault();
+            if (relayData.TryGetValue("Subject", out var subjectName))
+            {
+                authnRequest.Subject = new Saml2Subject(new Saml2NameIdentifier(subjectName));
+            } 
+            else if (!string.IsNullOrWhiteSpace(subjectString))
+            {
+                authnRequest.Subject = new Saml2Subject(new Saml2NameIdentifier(subjectString));
             }
 
             options.Notifications.AuthenticationRequestCreated(authnRequest, idp, relayData);

--- a/Tests/Tests.Shared/Saml2P/Saml2AuthenticationRequestTests.cs
+++ b/Tests/Tests.Shared/Saml2P/Saml2AuthenticationRequestTests.cs
@@ -93,6 +93,21 @@ namespace Sustainsys.Saml2.Tests.Saml2P
             subject.Should().NotBeNull().And.Subject.Attribute("IsPassive")
                 .Should().NotBeNull().And.Subject.Value.Should().Be("true");
         }
+        
+        [TestMethod]
+        public void Saml2AuthenticationRequest_Subject()
+        {
+            var subject = new Saml2AuthenticationRequest()
+            {
+                Subject = new Saml2Subject(new Saml2NameIdentifier("username"))
+            }.ToXElement();
+            
+            subject.Should().NotBeNull()
+                .And.Subject.Element(XNamespace.Get(Saml2Namespaces.Saml2Name) + "Subject").Should().NotBeNull()
+                .And.Subject.Elements().Should().HaveCount(2)
+                .And.Subject.First().Name.LocalName.Should().Be("NameID");
+            subject.Element(XNamespace.Get(Saml2Namespaces.Saml2Name) + "Subject")?.Elements().Last().Name.LocalName.Should().Be("SubjectConfirmation");
+        }
 
         [TestMethod]
         public void Saml2AuthenticationRequest_Extensions()


### PR DESCRIPTION
Should resolve #430
- Configurable either by URL or by relayData (Owin)

Please let me know if this is the correct approach or if I'd need to add other options as well. This just works for my use case where I want to pass a SAML "login_hint" to Keycloak.

If everything looks good, I'll add some tests as well.