### PR TITLE
PLT-18499 Change ValidAudience check to be idp specific

### DIFF
--- a/Sustainsys.Saml2/IdentityProvider.cs
+++ b/Sustainsys.Saml2/IdentityProvider.cs
@@ -40,7 +40,7 @@ namespace Sustainsys.Saml2
             OutboundSigningAlgorithm = spOptions.OutboundSigningAlgorithm;
         }
 
-        readonly SPOptions spOptions;
+        internal readonly SPOptions spOptions;
 
         internal IdentityProvider(IdentityProviderElement config, SPOptions spOptions)
         {

--- a/Sustainsys.Saml2/SAML2P/Saml2Response.cs
+++ b/Sustainsys.Saml2/SAML2P/Saml2Response.cs
@@ -602,7 +602,7 @@ namespace Sustainsys.Saml2.Saml2P
             }
 
             TokenValidationParameters validationParameters = options.SPOptions.TokenValidationParametersTemplate.Clone();
-            validationParameters.ValidAudience = options.SPOptions.EntityId.Id;
+            validationParameters.ValidAudience = idp.spOptions.EntityId.Id;
             validationParameters.TokenReplayCache = options.SPOptions.TokenReplayCache;
             validationParameters.ValidateTokenReplay = true;
 


### PR DESCRIPTION
Prior to making this call to "CreateClaims", if the idp that is returned by the GetIdentityProvider notification has a different configuration then the default spOptions, then we see the following error:
<img width="1497" alt="image" src="https://user-images.githubusercontent.com/71667899/220569259-e9eeb493-eba9-4b2c-ae97-1af0c9831c37.png">

This PR changes the validation audience based on the current identity provider rather then the entityid configured in spOptions. For our fork of the sustainsys library, this provided more customization as we have different identity providers per entityid. This change will allow users to check the audience against that specific identity provider.


