### PR TITLE
Explicitly target dotnet6 and use FrameworkReference in that case

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/Sustainsys.Saml2.AspNetCore2.csproj
+++ b/Sustainsys.Saml2.AspNetCore2/Sustainsys.Saml2.AspNetCore2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net47;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net47;net461;net6.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageReleaseNotes>$releaseNotes$</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -20,8 +20,11 @@
     <Authors>Sustainsys</Authors>
   </PropertyGroup>
 
+  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')))">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="!('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0')))">
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />


### PR DESCRIPTION
The `Sustainsys.Saml2.AspNetCore2` project references nuget packages that are no longer supported in `aspnetcore >=3`. 

This PR adds a new TFM (i picked `6`, but any version would do) and when using this new TFM, it uses [`FrameworkReference`](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/target-aspnetcore?view=aspnetcore-7.0&tabs=visual-studio#use-the-aspnet-core-shared-framework) instead of `PackageReference` to reference `aspnetcore` libraries