### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Sustainsys/Saml2/security/code-scanning/1](https://github.com/Sustainsys/Saml2/security/code-scanning/1)

The recommended way to fix this issue is to add a `permissions:` block to the workflow file to limit the access granted to the GITHUB_TOKEN according to the principle of least privilege. For this workflow, the build job only reads repository contents (cloning/checking out code and running build/test commands), so the minimal necessary permission is `contents: read`. This permissions block should be added at the root level (above `jobs:`), making it applicable to all jobs unless overridden elsewhere. You do not need to edit any other job, and no imports, external dependencies, or code logic changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
