### PR TITLE
Fix unnecessary thread pool junk/chained metadata refreshes

### DIFF
--- a/Sustainsys.Saml2/IdentityProvider.cs
+++ b/Sustainsys.Saml2/IdentityProvider.cs
@@ -538,7 +538,13 @@ namespace Sustainsys.Saml2
             {
                 lock (metadataLoadLock)
                 {
-                    DoLoadMetadata();
+					// check the metadata is still expired now we've waited
+					// for the lock to be free - it was probably locked by
+					// another thread performing the refresh
+					if (LoadMetadata && MetadataValidUntil.Value < DateTime.UtcNow)
+					{
+                    	DoLoadMetadata();
+					}
                 }
             }
         }


### PR DESCRIPTION
Ref: #1581

`DoLoadMetadata` ultimately results in a refresh (a non-async, thread-using continuation) being scheduled on the thread pool.

If multiple calls/checks are made concurrently, then due to this missing check, multiple checks will be scheduled on the pool.

Over time, the number of (unnecessary) scheduled checks can slowly grow, which uses up more and more threads on the pool, leading to application instability as actual application tasks and callbacks fail to find a free thread to run on.