### PR TITLE
Allow serialization of extensions for Requests

### DIFF
--- a/src/foss/Sustainsys.Saml2/Serialization/SamlXmlWriter.AuthnRequest.cs
+++ b/src/foss/Sustainsys.Saml2/Serialization/SamlXmlWriter.AuthnRequest.cs
@@ -30,6 +30,5 @@ partial class SamlXmlWriter
         var xe = Append(node, authnRequest, Elements.AuthnRequest);
         // TODO: Move to separate methods
         xe.SetAttributeIfValue(Attributes.AssertionConsumerServiceURL, authnRequest.AssertionConsumerServiceUrl);
-        AppendIfValue(xe, authnRequest.Issuer, Elements.Issuer);
     }
 }

--- a/src/foss/Sustainsys.Saml2/Serialization/SamlXmlWriter.RequestAbstractType.cs
+++ b/src/foss/Sustainsys.Saml2/Serialization/SamlXmlWriter.RequestAbstractType.cs
@@ -22,6 +22,8 @@ partial class SamlXmlWriter
         element.SetAttribute(Attributes.ID, request.Id);
         element.SetAttribute(Attributes.IssueInstant, request.IssueInstant);
         element.SetAttribute(Attributes.Version, request.Version);
+        
+        AppendIfValue(element, request.Issuer, Elements.Issuer);
 
         if (request.Extensions != null) {
             var extensionsElement = AppendElement(element, Namespaces.Samlp, Elements.Extensions);

--- a/src/foss/Sustainsys.Saml2/Serialization/SamlXmlWriter.RequestAbstractType.cs
+++ b/src/foss/Sustainsys.Saml2/Serialization/SamlXmlWriter.RequestAbstractType.cs
@@ -23,6 +23,14 @@ partial class SamlXmlWriter
         element.SetAttribute(Attributes.IssueInstant, request.IssueInstant);
         element.SetAttribute(Attributes.Version, request.Version);
 
+        if (request.Extensions != null) {
+            var extensionsElement = AppendElement(element, Namespaces.Samlp, Elements.Extensions);
+            foreach (var extension in request.Extensions.Contents.OfType<XmlElement>()) {
+                var extensionNode = extensionsElement.OwnerDocument.ImportNode(extension, true);
+                extensionsElement.AppendChild(extensionNode);
+            }
+        }
+
         return element;
     }
 }

--- a/src/foss/Tests/Sustainsys.Saml2.Tests/Serialization/SamlXmlWriterTests.AuthnRequest.cs
+++ b/src/foss/Tests/Sustainsys.Saml2.Tests/Serialization/SamlXmlWriterTests.AuthnRequest.cs
@@ -57,4 +57,38 @@ public partial class SamlXmlWriterTests
 
         actual.Should().BeEquivalentTo(expected);
     }
+
+    [Fact]
+    public void WriteAuthnRequest_IncludeExtension()
+    {
+        var document = new XmlDocument();
+        var extensionNode = document.CreateElement("test", "urn:test");
+
+        AuthnRequest authnRequest = new()
+        {
+            IssueInstant = new(2025, 01, 05, 15, 00, 00),
+            Extensions = new Common.Extensions
+            {
+                Contents = new List<object>
+                {
+                    extensionNode
+                }
+            }
+        };
+
+        var subject = new SamlXmlWriter();
+
+        var actual = subject.Write(authnRequest);
+
+        var xml =
+            $"<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
+            $"ID=\"{authnRequest.Id}\" IssueInstant=\"2025-01-05T15:00:00Z\" Version=\"2.0\">" +
+            $"<samlp:Extensions><test xmlns=\"urn:test\"/></samlp:Extensions>" +
+            $"</samlp:AuthnRequest>";
+
+        var expected = new XmlDocument();
+        expected.LoadXml(xml);
+
+        actual.Should().BeEquivalentTo(expected);
+    }
 }

--- a/src/foss/Tests/Sustainsys.Saml2.Tests/Serialization/SamlXmlWriterTests.AuthnRequest.cs
+++ b/src/foss/Tests/Sustainsys.Saml2.Tests/Serialization/SamlXmlWriterTests.AuthnRequest.cs
@@ -67,6 +67,7 @@ public partial class SamlXmlWriterTests
         AuthnRequest authnRequest = new()
         {
             IssueInstant = new(2025, 01, 05, 15, 00, 00),
+            Issuer = new("https://sp.example.com/Metadata"),
             Extensions = new Common.Extensions
             {
                 Contents = new List<object>
@@ -84,6 +85,7 @@ public partial class SamlXmlWriterTests
         var xml =
             $"<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
             $"ID=\"{authnRequest.Id}\" IssueInstant=\"2025-01-05T15:00:00Z\" Version=\"2.0\">" +
+            $"<saml:Issuer xmlns:saml=\"{Constants.Namespaces.SamlUri}\">https://sp.example.com/Metadata</saml:Issuer>" +
             $"<samlp:Extensions>" +
             $"<test xmlns=\"urn:test\"/>" +
             $"<test2 xmlns=\"urn:test\"/>" +

--- a/src/foss/Tests/Sustainsys.Saml2.Tests/Serialization/SamlXmlWriterTests.AuthnRequest.cs
+++ b/src/foss/Tests/Sustainsys.Saml2.Tests/Serialization/SamlXmlWriterTests.AuthnRequest.cs
@@ -61,9 +61,9 @@ public partial class SamlXmlWriterTests
     [Fact]
     public void WriteAuthnRequest_IncludeExtension()
     {
+        // The document is needed to create XmlElement instances for the extensions.
         var document = new XmlDocument();
-        var extensionNode = document.CreateElement("test", "urn:test");
-
+        
         AuthnRequest authnRequest = new()
         {
             IssueInstant = new(2025, 01, 05, 15, 00, 00),
@@ -71,7 +71,8 @@ public partial class SamlXmlWriterTests
             {
                 Contents = new List<object>
                 {
-                    extensionNode
+                    document.CreateElement("test", "urn:test"),
+                    document.CreateElement("test2", "urn:test")
                 }
             }
         };
@@ -83,7 +84,10 @@ public partial class SamlXmlWriterTests
         var xml =
             $"<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
             $"ID=\"{authnRequest.Id}\" IssueInstant=\"2025-01-05T15:00:00Z\" Version=\"2.0\">" +
-            $"<samlp:Extensions><test xmlns=\"urn:test\"/></samlp:Extensions>" +
+            $"<samlp:Extensions>" +
+            $"<test xmlns=\"urn:test\"/>" +
+            $"<test2 xmlns=\"urn:test\"/>" +
+            $"</samlp:Extensions>" +
             $"</samlp:AuthnRequest>";
 
         var expected = new XmlDocument();


### PR DESCRIPTION
Hi again,

this PR contains code to serialize AuthNRequest (or to be precise it's base class) Extensions, IF they are of type XmlElement.
I made this to move v3 to be compatible with Bund-ID.